### PR TITLE
refactor(04a): DH parameters — #define macros → constexpr RobotParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `CMakePresets.json` — `debug` and `release` presets (default generators, no toolchain files) making CMake the single, cross-platform build entry point.
 
 ### Changed
+- DH link dimensions moved from `#define UR*_LINK_DIMENSIONS_*` macros into a typed, single source of truth: `robotParameters.h` (`struct RobotParameters` + `constexpr kUR3/kUR5/kUR10` + `parametersFor()`). The `UR` constructor now copies `m_d`/`m_a` (now `std::array`) from `parametersFor(robotType)` instead of `memcpy` from macros. Values are bit-identical (same `float` literals); golden results unchanged.
 - `main.cpp` — removed the trailing `std::cin.get()` so `ur_app` runs to completion without keyboard input (required for CI smoke-running the demo). Console FK/IK output is otherwise unchanged.
 - Repository slimmed to the C++ library only. The MATLAB reference implementation, CoppeliaSim scenes/models, and `LAUNCH.md` moved to the archive repo [`Jgocunha/universal-robots-kinematics-matlab`](https://github.com/Jgocunha/universal-robots-kinematics-matlab); README updated to state the new scope and link the archive.
 - Moved `Resources/errorSolsFlow.png` → `docs/images/errorSolsFlow.png`.

--- a/cpp/universalRobotsKinematics/universalRobotsKinematics/src/robotParameters.h
+++ b/cpp/universalRobotsKinematics/universalRobotsKinematics/src/robotParameters.h
@@ -1,0 +1,47 @@
+// robotParameters.h
+
+#pragma once
+
+#include <array>
+
+namespace universalRobots
+{
+
+	/// <summary> URtype
+	/// Different types of URs.
+	/// </summary>
+	enum URtype : unsigned int
+	{
+		UR3, UR5, UR10 // 0, 1, 2
+	};
+
+	/// <summary>
+	/// Denavit-Hartenberg link dimensions (meters) for a UR model.
+	/// d - z-axis translations (d[6] is the end-effector slot); a - x-axis translations.
+	/// </summary>
+	struct RobotParameters
+	{
+		URtype type;
+		std::array<float, 7> d;
+		std::array<float, 4> a;
+	};
+
+	inline constexpr RobotParameters kUR3 { UR3,  { 0.1089f, 0.1115f, 0.0f, 0.0f, 0.0007f, 0.0818f, 0.0f }, { 0.2437f, 0.2132f, 0.0842f, 0.0011f } };
+	inline constexpr RobotParameters kUR5 { UR5,  { 0.0746f, 0.0703f, 0.0f, 0.0f, 0.0397f, 0.0829f, 0.0f }, { 0.4251f, 0.3922f, 0.0456f, 0.0492f } };
+	inline constexpr RobotParameters kUR10{ UR10, { 0.109f, 0.10122f, 0.01945f, -0.00661f, 0.0584f, 0.09372f, 0.0f }, { 0.6121f, 0.5722f, 0.0573f, 0.0584f } };
+
+	/// <summary>
+	/// Returns the DH parameters for a given UR model. Unknown values fall back to UR10.
+	/// </summary>
+	constexpr const RobotParameters& parametersFor(const URtype type)
+	{
+		switch (type)
+		{
+		case UR3:  return kUR3;
+		case UR5:  return kUR5;
+		case UR10: return kUR10;
+		default:   return kUR10;
+		}
+	}
+
+} // namespace universalRobots

--- a/cpp/universalRobotsKinematics/universalRobotsKinematics/src/universalRobotsKinematics.cpp
+++ b/cpp/universalRobotsKinematics/universalRobotsKinematics/src/universalRobotsKinematics.cpp
@@ -17,26 +17,10 @@ namespace universalRobots
 	/// <param name="endEffectorDimension"></param>
 	UR::UR(const URtype& robotType, const bool& endEffector, const float& endEffectorDimension)
 		: m_type(robotType), m_endEffector(endEffector)
-	{	
-		switch (robotType)
-		{
-		case universalRobots::URtype::UR3:
-			setTransZ(UR3_LINK_DIMENSIONS_d);
-			setTransX(UR3_LINK_DIMENSIONS_a);
-			break;
-		case universalRobots::URtype::UR5:
-			setTransZ(UR5_LINK_DIMENSIONS_d);
-			setTransX(UR5_LINK_DIMENSIONS_a);
-			break;
-		case universalRobots::URtype::UR10:
-			setTransZ(UR10_LINK_DIMENSIONS_d);
-			setTransX(UR10_LINK_DIMENSIONS_a);
-			break;
-		default:
-			setTransZ(UR10_LINK_DIMENSIONS_d);
-			setTransX(UR10_LINK_DIMENSIONS_a);
-			break;
-		}
+	{
+		const RobotParameters& params = parametersFor(robotType);
+		m_d = params.d;
+		m_a = params.a;
 
 		m_d[m_numTransZ - 1] = endEffectorDimension;
 		m_MDHmatrix <<  0.0f,				0.0f,		m_d[0],			m_jointState[0].m_jointValue,						// 0T1
@@ -57,24 +41,6 @@ namespace universalRobots
 	void UR::setRobotType(const URtype& type)
 	{
 		m_type = type;
-	}
-
-	/// <summary>
-	/// setTransZ
-	/// </summary>
-	/// <param name="d"></param>
-	void UR::setTransZ(const float(&d)[])
-	{
-		memcpy(m_d, d, sizeof(m_d));
-	}
-	
-	/// <summary>
-	/// setTransX
-	/// </summary>
-	/// <param name="a"></param>
-	void UR::setTransX(const float(&a)[])
-	{
-		memcpy(m_a, a, sizeof(m_a));
 	}
 
 	/// <summary>
@@ -118,7 +84,7 @@ namespace universalRobots
 	/// <returns>m_d</returns>
 	const float* UR::getTransZ() const
 	{
-		return m_d;
+		return m_d.data();
 	}
 	
 	/// <summary>
@@ -127,7 +93,7 @@ namespace universalRobots
 	/// <returns>m_a</returns>
 	const float* UR::getTransX() const
 	{
-		return m_a;
+		return m_a.data();
 	}
 	
 	/// <summary>

--- a/cpp/universalRobotsKinematics/universalRobotsKinematics/src/universalRobotsKinematics.h
+++ b/cpp/universalRobotsKinematics/universalRobotsKinematics/src/universalRobotsKinematics.h
@@ -3,28 +3,13 @@
 #pragma once
 
 #include <iostream>
+#include <array>
 #include <Eigen/Dense>
 #include "mathLib.h"
-
-#define UR3_LINK_DIMENSIONS_d { 0.1089f, 0.1115f, 0.0f, 0.0f, 0.0007f, 0.0818f, 0.0f }
-#define UR3_LINK_DIMENSIONS_a { 0.2437f, 0.2132f, 0.0842f, 0.0011f }
-
-#define UR5_LINK_DIMENSIONS_d { 0.0746f, 0.0703f, 0.0f, 0.0f, 0.0397f, 0.0829f, 0.0f }
-#define UR5_LINK_DIMENSIONS_a { 0.4251f, 0.3922f, 0.0456f, 0.0492f }
-
-#define UR10_LINK_DIMENSIONS_d { 0.109f, 0.10122f, 0.01945f, -0.00661f, 0.0584f, 0.09372f, 0.0f }
-#define UR10_LINK_DIMENSIONS_a { 0.6121f, 0.5722f, 0.0573f, 0.0584f }
+#include "robotParameters.h"
 
 namespace universalRobots
 {
-	
-	/// <summary> URtype
-	/// Different types of URs.
-	/// </summary>
-	enum URtype : unsigned int
-	{
-		UR3, UR5, UR10 // 0, 1, 2
-	};
 
 	/// <summary>
 	/// Structure which holds a pose { x y z } { alpha beta gamma }
@@ -143,13 +128,13 @@ namespace universalRobots
 		/// d - translation (meters) in the z-axis (the last translation d[6] is for an end-effector).
 		/// d_i is a nomeclature convention. 
 		/// </summary>
-		float m_d[m_numTransZ] = UR10_LINK_DIMENSIONS_d;
+		std::array<float, m_numTransZ> m_d = kUR10.d;
 		
 		/// <summary>
 		/// a - translation (meters) in the x-axis.
 		/// a_i is a nomeclature convention.
 		/// </summary>
-		float m_a[m_numTransX] = UR10_LINK_DIMENSIONS_a;
+		std::array<float, m_numTransX> m_a = kUR10.a;
 		
 		/// <summary>
 		/// Position, Euler Angles, and Value of the robot's joints. {x, y, z} {alpha, beta, gamma} {jointValue}
@@ -180,8 +165,6 @@ namespace universalRobots
 	private:
 		void setMDHmatrix();
 		void setRobotType(const URtype& type);
-		void setTransZ(const float (&d)[]);
-		void setTransX(const float (&a)[]);
 		void setTheta(const float (&jointVal)[]);
 		const float* getTransZ() const;
 		const float* getTransX() const;


### PR DESCRIPTION
## Task 04a — DH parameters: `#define` macros → `constexpr` structs

Replaces the per-model `#define UR*_LINK_DIMENSIONS_*` macros (brace-init lists `memcpy`'d into member C-arrays) with a typed, single source of truth.

### Changes
- **New `robotParameters.h`**: `struct RobotParameters { URtype type; std::array<float,7> d; std::array<float,4> a; }`, `inline constexpr kUR3/kUR5/kUR10` (float literals copied **verbatim** from the deleted macros / BASELINE.md), and `constexpr const RobotParameters& parametersFor(URtype)` defaulting to UR10. The `enum URtype` moved here so the data header is self-contained (no Eigen, no circular include); `universalRobotsKinematics.h` includes it.
- **`universalRobotsKinematics.h`**: deleted the 6 macros; `m_d`/`m_a` are now `std::array<float,7/4>` defaulting to `kUR10.d/.a`; removed the now-unused `setTransZ`/`setTransX` declarations.
- **`universalRobotsKinematics.cpp`**: constructor copies `m_d`/`m_a` from `parametersFor(robotType)` instead of the macro `switch` + `memcpy`; deleted `setTransZ`/`setTransX`; `getTransZ`/`getTransX` return `.data()`. Quirk **Q8** preserved exactly (`m_d[6] = endEffectorDimension` unconditionally).

### Bit-identical
Same `float` literals → results are byte-identical, not merely within tolerance.
- `git grep LINK_DIMENSIONS` → empty; `git grep memcpy -- cpp/` → empty.
- Local (Windows, Release): build clean, **ctest 6/6**, `ur_app` exit 0, UR5 fixture tip pose still exactly **0.284738 / 0.260623 / 0.666385**.

Zero changes to kinematics *math*; only the data-plumbing shape changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)