### PR TITLE
chore: static analysis + formatting (closes #27)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+# Base style chosen to match the existing code (Allman braces, tab indentation,
+# indented namespace bodies, left-aligned reference/pointer) as closely as
+# possible, to minimize the diff of the one-time reformat commit.
+BasedOnStyle: Microsoft
+UseTab: Always
+IndentWidth: 4
+TabWidth: 4
+ColumnLimit: 120
+NamespaceIndentation: All
+PointerAlignment: Left
+ReferenceAlignment: Left
+SortIncludes: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,6 +19,7 @@ Checks: >
   clang-analyzer-*,
   performance-*,
   -performance-enum-size,
+  -performance-type-promotion-in-math-fn,
   cppcoreguidelines-*,
   -cppcoreguidelines-narrowing-conversions,
   -cppcoreguidelines-avoid-c-arrays,
@@ -56,6 +57,14 @@ Checks: >
 #   scope here (non-goal: no functional changes).
 # - performance-enum-size: URtype is a public API enum; shrinking its
 #   underlying type is an ABI-affecting change out of scope for a lint task.
+# - performance-type-promotion-in-math-fn: fires on unqualified sin/cos/atan2/asin
+#   calls throughout the IK/FK solver and calcTransformationMatrix — but only on
+#   Linux/libstdc++ (clang-tidy-18), not on the Windows/MSVC STL toolchain used to
+#   author this config, which is itself the exact kind of platform-dependent libm
+#   overload-resolution difference task 04f already had to work around. Qualifying
+#   these calls (or adding casts) to silence it risks nudging which overload gets
+#   selected on one platform vs. the other; not something to do as a drive-by lint
+#   fix without a dedicated cross-platform numerical review.
 # - cppcoreguidelines-pro-bounds-constant-array-index: fires ~74 times on
 #   ordinary compile-time-constant indexing into fixed-size DH-parameter and
 #   joint arrays (m_d[i], m_a[i], ...) — the normal, safe way to write this

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,36 +1,66 @@
-# This codebase predates clang-tidy adoption, so checks that would flag purely
-# pre-existing style (not a correctness risk) across most of the file are disabled
-# below rather than forcing a bulk unrelated rewrite. bugprone-narrowing-conversions
-# is disabled too: the flagged sites are float<->double interop inside the IK/FK
-# solver, which is fragile floating-point code (see task 04f) — not something to
-# touch casually as a side effect of a static-analysis setup change.
+# Curated check set (task 05). Every finding below is either fixed in-code,
+# NOLINT'd with a one-line justification at the call site, or its whole check
+# is disabled here with a comment explaining why re-enabling it repo-wide
+# wouldn't be worth the diff/risk. See task 05 for the reconciliation from
+# #40's blanket per-category disables to this curated list.
 Checks: >
   -*,
   bugprone-*,
-  -bugprone-easily-swappable-parameters,
-  -bugprone-branch-clone,
   -bugprone-narrowing-conversions,
   modernize-*,
   -modernize-use-trailing-return-type,
   -modernize-avoid-c-arrays,
-  -modernize-use-nodiscard,
-  -modernize-return-braced-init-list,
   readability-*,
   -readability-magic-numbers,
   -readability-identifier-length,
   -readability-uppercase-literal-suffix,
   -readability-braces-around-statements,
-  -readability-static-accessed-through-instance,
   -readability-function-cognitive-complexity,
-  -readability-convert-member-functions-to-static,
-  -readability-use-anyofallof,
-  -readability-redundant-member-init,
-  -readability-implicit-bool-conversion,
   clang-analyzer-*,
   performance-*,
   -performance-enum-size,
-  -performance-avoid-endl,
-  -performance-type-promotion-in-math-fn
+  cppcoreguidelines-*,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-pro-bounds-constant-array-index
+
+# Disabled-check rationale:
+# - {bugprone,cppcoreguidelines}-narrowing-conversions: sites are float<->double
+#   interop inside the fragile IK/FK solver (see task 04f, wrist-singularity
+#   theta5 sign flip from a sub-ULP libm difference). Not to be touched as a
+#   side effect of a lint pass; fix or NOLINT case-by-case only with a real
+#   numerical-stability review, not here.
+# - modernize-use-trailing-return-type: pure style preference, not used
+#   anywhere in this codebase; would rewrite ~40 signatures for no safety
+#   or readability gain.
+# - {modernize,cppcoreguidelines}-avoid-c-arrays: flags pose::m_pos/m_eulerAngles
+#   and the (const float(&)[3], ...) constructor params. These are public API
+#   read directly by tests/demo/benchmarking code; switching to std::array
+#   would be an API-breaking redesign, out of scope for a no-functional-change
+#   lint task.
+# - readability-magic-numbers / cppcoreguidelines-avoid-magic-numbers: this is
+#   DH-parameter and joint-index-heavy geometry code; nearly every literal
+#   would need a named constant with no real readability win.
+# - readability-identifier-length: short math-notation names (i, j, a, d, T_01,
+#   theta*, ...) are the domain convention here.
+# - readability-uppercase-literal-suffix: repo consistently uses lowercase `f`
+#   suffix (69 sites); flipping the convention is a pure-style, zero-benefit
+#   diff across the whole codebase.
+# - readability-braces-around-statements: repo convention is brace-less
+#   single-statement bodies; enabling would force braces on ~27 sites for a
+#   style preference, not a bug.
+# - readability-function-cognitive-complexity: inverseKinematics() is
+#   inherently branchy (8 IK solution branches from the geometric method);
+#   splitting it up is a real refactor with behavior-change risk, out of
+#   scope here (non-goal: no functional changes).
+# - performance-enum-size: URtype is a public API enum; shrinking its
+#   underlying type is an ABI-affecting change out of scope for a lint task.
+# - cppcoreguidelines-pro-bounds-constant-array-index: fires ~74 times on
+#   ordinary compile-time-constant indexing into fixed-size DH-parameter and
+#   joint arrays (m_d[i], m_a[i], ...) — the normal, safe way to write this
+#   domain's code; .at() churn here adds exception-based bounds checks with
+#   no real benefit since the indices are compile-time constants.
 
 # Public library headers only; the demo app under apps/ is excluded.
 HeaderFilterRegex: 'include[/\\]ur_kinematics[/\\].*'

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# One-time clang-format reformat commits. Configure git to use this file with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+8cec8ad485c1909b9fce9a7fa836d64887495259

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,10 +16,16 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang clang-tidy clang-format cppcheck cmake
+          sudo apt-get install -y clang clang-tidy cppcheck cmake
+          # Pin clang-format to the exact version used to author .clang-format and
+          # generate the one-time reformat commit — the distro package drifts
+          # (e.g. Ubuntu ships 18.x) and produces different line-wrapping decisions.
+          pip install --user clang-format==19.1.5
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Check formatting
         run: |
+          clang-format --version
           find include src apps tests -name '*.h' -o -name '*.hpp' -o -name '*.cpp' | \
             xargs clang-format --dry-run -Werror
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Check formatting
         run: |
           clang-format --version
-          find include src apps tests -name '*.h' -o -name '*.hpp' -o -name '*.cpp' | \
-            xargs clang-format --dry-run -Werror
+          find include src apps tests \( -name '*.h' -o -name '*.hpp' -o -name '*.cpp' \) -print0 | \
+            xargs -0 clang-format --dry-run -Werror
 
       - name: Run cppcheck
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,7 +16,17 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang clang-tidy cmake
+          sudo apt-get install -y clang clang-tidy clang-format cppcheck cmake
+
+      - name: Check formatting
+        run: |
+          find include src apps tests -name '*.h' -o -name '*.hpp' -o -name '*.cpp' | \
+            xargs clang-format --dry-run -Werror
+
+      - name: Run cppcheck
+        run: |
+          cppcheck --enable=warning,performance,portability --error-exitcode=1 \
+            --inline-suppr -I include -I src --std=c++20 --language=c++ src apps
 
       - name: Cache FetchContent dependencies
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `docs/REFERENCES.md` — full citations (with DOIs/links) for the literature previously vendored as PDFs under `Articles/`, plus the project dissertations, Jazar's textbook, and UR manufacturer docs.
 - `tests/` — golden characterization suite (GoogleTest via FetchContent, CTest-discovered): FK/IK/round-trip parity tests replaying frozen v1.0 reference data in `tests/golden/*.json`, a one-shot `golden_generator`, and a dependency-free JSON reader. Zero changes to library code under `cpp/`.
 - `CMakePresets.json` — `debug` and `release` presets (default generators, no toolchain files) making CMake the single, cross-platform build entry point.
+- `.clang-format` — Microsoft-based style (Allman braces, tab indent, 120 col) applied once to `include/ src/ apps/ tests/` in a dedicated commit (`.git-blame-ignore-revs` entry included); enforced in CI via `clang-format --dry-run -Werror`.
+- cppcheck (`--enable=warning,performance,portability --error-exitcode=1 --inline-suppr`) added to the static-analysis CI job.
+- Warnings-as-errors (`-Wall -Wextra -Wpedantic` on GCC/Clang, `/W4` on MSVC) for `ur_kinematics`, `ur_demo`, and the test executables only, via `target_compile_options` on a `project_warnings` interface target — never applied globally, so FetchContent'd Eigen/GoogleTest are unaffected.
 
 ### Changed
 - Project layout reorganized to a conventional `include/` / `src/` / `apps/` structure (behavior-preserving; golden results byte-identical): public headers live in `include/ur_kinematics/` (`ur_kinematics.h`, `robot_parameters.h`) and are consumed as `#include <ur_kinematics/ur_kinematics.h>`; the library implementation and the private `math_utils` helper (ex-`mathLib`, folded into the `universalRobots` namespace) live in `src/`; the demo app moved to `apps/demo/`. The build is now a single `ur_kinematics` static library plus the `ur_demo` executable (renamed from `ur_app`); the separate `math_lib` target and the nested `cpp/` tree are gone. The `ITERATIONS` benchmark macro became a `constexpr`. The `universalRobots` namespace is unchanged (any rename is a one-line follow-up).
@@ -21,6 +24,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Repository slimmed to the C++ library only. The MATLAB reference implementation, CoppeliaSim scenes/models, and `LAUNCH.md` moved to the archive repo [`Jgocunha/universal-robots-kinematics-matlab`](https://github.com/Jgocunha/universal-robots-kinematics-matlab); README updated to state the new scope and link the archive.
 - Moved `Resources/errorSolsFlow.png` → `docs/images/errorSolsFlow.png`.
 - `.gitignore` replaced with a proper C++/CMake/IDE ignore set (`build*/`, `out/`, `.vs/`, `.vscode/`, `*.user`, `CMakeUserPresets.json`, OS junk); `.claude/` kept ignored.
+- `.clang-tidy` reconciled from a blanket 16-category disable to a curated `bugprone-*`/`modernize-*`/`readability-*`/`performance-*`/`cppcoreguidelines-*` set: every finding is fixed in-code, `NOLINT`'d with a justification, or its check is disabled with a documented reason. The fragile IK/FK solver math (task 04f) is protected from behavior-changing tidy fixes.
+
+### Fixed
+- `IkSolutions::valid` left uninitialized when default-constructed without `= {}` (cppcheck `uninitMemberVarNoCtor`).
+- Benchmark demo: `std::chrono::duration` accumulators (`sumInvKin_us`, `sumFwdKin_us`, ...) were left uninitialized before their first `+=`, and an outer `tipPoseInput` was fully shadowed (and thus dead) by an inner loop-scoped variable of the same name — both caught by `-Wall`/`/W4` and cppcheck while wiring up warnings-as-errors.
 
 ### Removed
 - CoppeliaSim remote-API integration: `Dependencies/CoppeliaSim/`, `Application/src/coppeliasimTests.{h,cpp}`, the vendored `extApi*`/`extApiPlatform*` sources, the `WITH_COPPELIASIM` CMake option, and the `#ifdef WITH_COPPELIASIM` blocks in `main.cpp`. The simulator integration lives in the archive repo [`Jgocunha/universal-robots-kinematics-matlab`](https://github.com/Jgocunha/universal-robots-kinematics-matlab).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,15 @@ project(universal_robots_kinematics LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Warnings-as-errors for our own targets only. Applied per-target via
+# target_compile_options (never add_compile_options), so FetchContent'd
+# dependencies (Eigen, GoogleTest) are unaffected.
+add_library(project_warnings INTERFACE)
+target_compile_options(project_warnings INTERFACE
+    $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 include(FetchContent)
 
 FetchContent_Declare(
@@ -16,6 +25,12 @@ set(EIGEN_BUILD_DOC OFF CACHE BOOL "" FORCE)
 set(BUILD_TESTING   OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(Eigen3)
 
+# Eigen's own headers trip our -Wall/-Wextra/-Wpedantic /-W4 (its CMakeLists
+# doesn't mark its include dirs SYSTEM). Re-add them as SYSTEM on our targets
+# so warnings-as-errors only applies to our own code, not template
+# instantiations that originate inside Eigen headers.
+get_target_property(EIGEN_INCLUDE_DIRS Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
+
 # --- ur_kinematics: the kinematics library (public headers in include/) ----------
 add_library(ur_kinematics STATIC
     src/ur_kinematics.cpp
@@ -25,7 +40,8 @@ target_include_directories(ur_kinematics
     PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
-target_link_libraries(ur_kinematics PUBLIC Eigen3::Eigen)
+target_include_directories(ur_kinematics SYSTEM PUBLIC ${EIGEN_INCLUDE_DIRS})
+target_link_libraries(ur_kinematics PUBLIC Eigen3::Eigen PRIVATE project_warnings)
 
 # --- ur_demo: the console demo application ----------------------------------------
 add_executable(ur_demo
@@ -33,7 +49,7 @@ add_executable(ur_demo
     apps/demo/benchmarking.cpp
 )
 target_include_directories(ur_demo PRIVATE apps/demo)
-target_link_libraries(ur_demo PRIVATE ur_kinematics)
+target_link_libraries(ur_demo PRIVATE ur_kinematics project_warnings)
 
 enable_testing()
 add_subdirectory(tests)

--- a/apps/demo/benchmarking.cpp
+++ b/apps/demo/benchmarking.cpp
@@ -3,7 +3,6 @@
 #include <iostream>
 #include "benchmarking.h"
 
-
 namespace benchmark
 {
 	void runBenchmarkTests(universalRobots::UR& robot)
@@ -39,7 +38,8 @@ namespace benchmark
 
 			for (unsigned int j = 0; j < robot.m_numIkSol; j++)
 			{
-				if (!ikSols.valid[j]) continue;
+				if (!ikSols.valid[j])
+					continue;
 
 				{
 					timer fkTimer;
@@ -55,14 +55,16 @@ namespace benchmark
 		avgFwdKin_us = fkCalls > 0 ? sumFwdKin_us / fkCalls : std::chrono::duration<double, std::micro>::zero();
 		avgPoseError = poseError / (ITERATIONS * robot.m_numIkSol);
 
-		std::cout << "Generated " << ITERATIONS << " random valid tip poses for " << robot.getRobotType() << "..." << std::endl;
+		std::cout << "Generated " << ITERATIONS << " random valid tip poses for " << robot.getRobotType() << "..."
+				  << std::endl;
 		std::cout << "Generated eight inverse kinematic solutions for each tip pose..." << std::endl;
 		std::cout << "Average IK function execution time: " << avgInvKin_us.count() << "us" << std::endl;
 		std::cout << "Each IK sol (" << fkCalls << ") has been run through forward kinematics..." << std::endl;
 		std::cout << "Average FK function execution time: " << avgFwdKin_us.count() << "us" << std::endl;
 		std::cout << "error = [tip_pose_input - tip_pose_output]" << std::endl;
-		std::cout << "average error = " << avgPoseError.m_pos[0] << " " << avgPoseError.m_pos[1] << " " << avgPoseError.m_pos[2] << " "
-			<< avgPoseError.m_eulerAngles[0] << " " << avgPoseError.m_eulerAngles[1] << " " << avgPoseError.m_eulerAngles[2] << std::endl;
+		std::cout << "average error = " << avgPoseError.m_pos[0] << " " << avgPoseError.m_pos[1] << " "
+				  << avgPoseError.m_pos[2] << " " << avgPoseError.m_eulerAngles[0] << " "
+				  << avgPoseError.m_eulerAngles[1] << " " << avgPoseError.m_eulerAngles[2] << std::endl;
 	}
 
 	std::chrono::microseconds timer::stop()
@@ -72,7 +74,7 @@ namespace benchmark
 		auto start = std::chrono::time_point_cast<std::chrono::microseconds>(m_startTimePoint);
 		auto end = std::chrono::time_point_cast<std::chrono::microseconds>(m_endTimePoint);
 
-		return end - start;		
+		return end - start;
 	}
 
 } // namespace benchmark

--- a/apps/demo/benchmarking.cpp
+++ b/apps/demo/benchmarking.cpp
@@ -10,7 +10,6 @@ namespace benchmark
 		std::cout << "____________________________\nBenchmarking..." << '\n' << '\n';
 
 		universalRobots::UR::IkSolutions ikSols = {};
-		universalRobots::pose tipPoseInput = {};
 		universalRobots::pose tipPoseOutput = {};
 		universalRobots::pose poseError = {};
 		universalRobots::pose avgPoseError = {};

--- a/apps/demo/benchmarking.cpp
+++ b/apps/demo/benchmarking.cpp
@@ -7,7 +7,7 @@ namespace benchmark
 {
 	void runBenchmarkTests(universalRobots::UR& robot)
 	{
-		std::cout << "____________________________\nBenchmarking..." << std::endl << std::endl;
+		std::cout << "____________________________\nBenchmarking..." << '\n' << '\n';
 
 		universalRobots::UR::IkSolutions ikSols = {};
 		universalRobots::pose tipPoseInput = {};
@@ -15,13 +15,13 @@ namespace benchmark
 		universalRobots::pose poseError = {};
 		universalRobots::pose avgPoseError = {};
 
-		std::chrono::duration<double, std::micro> invKin_us;
-		std::chrono::duration<double, std::micro> sumInvKin_us;
-		std::chrono::duration<double, std::micro> avgInvKin_us;
+		std::chrono::duration<double, std::micro> invKin_us{};
+		std::chrono::duration<double, std::micro> sumInvKin_us{};
+		std::chrono::duration<double, std::micro> avgInvKin_us{};
 
-		std::chrono::duration<double, std::micro> fwdKin_us;
-		std::chrono::duration<double, std::micro> sumFwdKin_us;
-		std::chrono::duration<double, std::micro> avgFwdKin_us;
+		std::chrono::duration<double, std::micro> fwdKin_us{};
+		std::chrono::duration<double, std::micro> sumFwdKin_us{};
+		std::chrono::duration<double, std::micro> avgFwdKin_us{};
 
 		unsigned int fkCalls = 0;
 
@@ -36,7 +36,7 @@ namespace benchmark
 			}
 			sumInvKin_us = sumInvKin_us + invKin_us;
 
-			for (unsigned int j = 0; j < robot.m_numIkSol; j++)
+			for (unsigned int j = 0; j < universalRobots::UR::m_numIkSol; j++)
 			{
 				if (!ikSols.valid[j])
 					continue;
@@ -53,18 +53,18 @@ namespace benchmark
 		}
 		avgInvKin_us = sumInvKin_us / ITERATIONS;
 		avgFwdKin_us = fkCalls > 0 ? sumFwdKin_us / fkCalls : std::chrono::duration<double, std::micro>::zero();
-		avgPoseError = poseError / (ITERATIONS * robot.m_numIkSol);
+		avgPoseError = poseError / (ITERATIONS * universalRobots::UR::m_numIkSol);
 
 		std::cout << "Generated " << ITERATIONS << " random valid tip poses for " << robot.getRobotType() << "..."
-				  << std::endl;
-		std::cout << "Generated eight inverse kinematic solutions for each tip pose..." << std::endl;
-		std::cout << "Average IK function execution time: " << avgInvKin_us.count() << "us" << std::endl;
-		std::cout << "Each IK sol (" << fkCalls << ") has been run through forward kinematics..." << std::endl;
-		std::cout << "Average FK function execution time: " << avgFwdKin_us.count() << "us" << std::endl;
-		std::cout << "error = [tip_pose_input - tip_pose_output]" << std::endl;
+				  << '\n';
+		std::cout << "Generated eight inverse kinematic solutions for each tip pose..." << '\n';
+		std::cout << "Average IK function execution time: " << avgInvKin_us.count() << "us" << '\n';
+		std::cout << "Each IK sol (" << fkCalls << ") has been run through forward kinematics..." << '\n';
+		std::cout << "Average FK function execution time: " << avgFwdKin_us.count() << "us" << '\n';
+		std::cout << "error = [tip_pose_input - tip_pose_output]" << '\n';
 		std::cout << "average error = " << avgPoseError.m_pos[0] << " " << avgPoseError.m_pos[1] << " "
 				  << avgPoseError.m_pos[2] << " " << avgPoseError.m_eulerAngles[0] << " "
-				  << avgPoseError.m_eulerAngles[1] << " " << avgPoseError.m_eulerAngles[2] << std::endl;
+				  << avgPoseError.m_eulerAngles[1] << " " << avgPoseError.m_eulerAngles[2] << '\n';
 	}
 
 	std::chrono::microseconds timer::stop()

--- a/apps/demo/benchmarking.h
+++ b/apps/demo/benchmarking.h
@@ -22,9 +22,8 @@ namespace benchmark
 		std::chrono::time_point<std::chrono::high_resolution_clock> m_endTimePoint;
 
 	  public:
-		timer()
+		timer() : m_startTimePoint(std::chrono::high_resolution_clock::now())
 		{
-			m_startTimePoint = std::chrono::high_resolution_clock::now();
 		}
 		std::chrono::microseconds stop();
 	};

--- a/apps/demo/benchmarking.h
+++ b/apps/demo/benchmarking.h
@@ -17,10 +17,11 @@ namespace benchmark
 
 	class timer
 	{
-	private:
+	  private:
 		std::chrono::time_point<std::chrono::high_resolution_clock> m_startTimePoint;
 		std::chrono::time_point<std::chrono::high_resolution_clock> m_endTimePoint;
-	public:
+
+	  public:
 		timer()
 		{
 			m_startTimePoint = std::chrono::high_resolution_clock::now();

--- a/apps/demo/main.cpp
+++ b/apps/demo/main.cpp
@@ -4,7 +4,6 @@
 #include <ur_kinematics/ur_kinematics.h>
 #include "benchmarking.h"
 
-
 int main()
 {
 	// instatiate a UR object
@@ -13,7 +12,9 @@ int main()
 
 	// test different target joint values
 	//
-	const universalRobots::UR::JointVector targetJointValues = { universalRobots::rad(23), universalRobots::rad(345), universalRobots::rad(78), universalRobots::rad(66), universalRobots::rad(77), universalRobots::rad(12) };
+	const universalRobots::UR::JointVector targetJointValues = {universalRobots::rad(23), universalRobots::rad(345),
+																universalRobots::rad(78), universalRobots::rad(66),
+																universalRobots::rad(77), universalRobots::rad(12)};
 
 	// compute forward kinematics and update robot's tip pose
 	//
@@ -27,8 +28,11 @@ int main()
 
 	std::cout << "Inverse kinematics" << std::endl;
 	for (unsigned int i = 0; i < robot.m_numIkSol; i++)
-		std::cout << "IK solution " << i + 1 << ": " << universalRobots::deg(ikSols.solutions[i][0]) << " " << universalRobots::deg(ikSols.solutions[i][1]) << " " << universalRobots::deg(ikSols.solutions[i][2]) << " " <<
-		universalRobots::deg(ikSols.solutions[i][3]) << " " << universalRobots::deg(ikSols.solutions[i][4]) << " " << universalRobots::deg(ikSols.solutions[i][5]) << std::endl;
+		std::cout << "IK solution " << i + 1 << ": " << universalRobots::deg(ikSols.solutions[i][0]) << " "
+				  << universalRobots::deg(ikSols.solutions[i][1]) << " " << universalRobots::deg(ikSols.solutions[i][2])
+				  << " " << universalRobots::deg(ikSols.solutions[i][3]) << " "
+				  << universalRobots::deg(ikSols.solutions[i][4]) << " " << universalRobots::deg(ikSols.solutions[i][5])
+				  << std::endl;
 
 	// benchmarking
 	//

--- a/apps/demo/main.cpp
+++ b/apps/demo/main.cpp
@@ -4,40 +4,57 @@
 #include <ur_kinematics/ur_kinematics.h>
 #include "benchmarking.h"
 
+// The whole body is wrapped in a try/catch(const std::exception&)/catch(...),
+// which is exhaustive; the checker can't see that catch(...) covers everything.
+// NOLINTNEXTLINE(bugprone-exception-escape)
 int main()
 {
-	// instatiate a UR object
-	//
-	universalRobots::UR robot(universalRobots::URtype::UR5);
+	try
+	{
+		// instatiate a UR object
+		//
+		universalRobots::UR robot(universalRobots::URtype::UR5);
 
-	// test different target joint values
-	//
-	const universalRobots::UR::JointVector targetJointValues = {universalRobots::rad(23), universalRobots::rad(345),
-																universalRobots::rad(78), universalRobots::rad(66),
-																universalRobots::rad(77), universalRobots::rad(12)};
+		// test different target joint values
+		//
+		const universalRobots::UR::JointVector targetJointValues = {universalRobots::rad(23), universalRobots::rad(345),
+																	universalRobots::rad(78), universalRobots::rad(66),
+																	universalRobots::rad(77), universalRobots::rad(12)};
 
-	// compute forward kinematics and update robot's tip pose
-	//
-	const universalRobots::pose targetTipPose = robot.forwardKinematics(targetJointValues);
+		// compute forward kinematics and update robot's tip pose
+		//
+		const universalRobots::pose targetTipPose = robot.forwardKinematics(targetJointValues);
 
-	std::cout << robot << std::endl;
+		std::cout << robot << '\n';
 
-	// compute inverse kinematics
-	//
-	const universalRobots::UR::IkSolutions ikSols = robot.inverseKinematics(targetTipPose);
+		// compute inverse kinematics
+		//
+		const universalRobots::UR::IkSolutions ikSols = robot.inverseKinematics(targetTipPose);
 
-	std::cout << "Inverse kinematics" << std::endl;
-	for (unsigned int i = 0; i < robot.m_numIkSol; i++)
-		std::cout << "IK solution " << i + 1 << ": " << universalRobots::deg(ikSols.solutions[i][0]) << " "
-				  << universalRobots::deg(ikSols.solutions[i][1]) << " " << universalRobots::deg(ikSols.solutions[i][2])
-				  << " " << universalRobots::deg(ikSols.solutions[i][3]) << " "
-				  << universalRobots::deg(ikSols.solutions[i][4]) << " " << universalRobots::deg(ikSols.solutions[i][5])
-				  << std::endl;
+		std::cout << "Inverse kinematics" << '\n';
+		for (unsigned int i = 0; i < universalRobots::UR::m_numIkSol; i++)
+			std::cout << "IK solution " << i + 1 << ": " << universalRobots::deg(ikSols.solutions[i][0]) << " "
+					  << universalRobots::deg(ikSols.solutions[i][1]) << " "
+					  << universalRobots::deg(ikSols.solutions[i][2]) << " "
+					  << universalRobots::deg(ikSols.solutions[i][3]) << " "
+					  << universalRobots::deg(ikSols.solutions[i][4]) << " "
+					  << universalRobots::deg(ikSols.solutions[i][5]) << '\n';
 
-	// benchmarking
-	//
-	universalRobots::UR benchmarkRobot(universalRobots::URtype::UR5);
-	benchmark::runBenchmarkTests(benchmarkRobot);
+		// benchmarking
+		//
+		universalRobots::UR benchmarkRobot(universalRobots::URtype::UR5);
+		benchmark::runBenchmarkTests(benchmarkRobot);
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << "ur_demo failed: " << e.what() << '\n';
+		return 1;
+	}
+	catch (...)
+	{
+		std::cerr << "ur_demo failed: unknown exception" << '\n';
+		return 1;
+	}
 
 	return 0;
 }

--- a/include/ur_kinematics/robot_parameters.h
+++ b/include/ur_kinematics/robot_parameters.h
@@ -28,12 +28,15 @@ namespace universalRobots
 		std::array<float, 4> a;
 	};
 
-	inline constexpr RobotParameters kUR3{
-		UR3, {0.1089f, 0.1115f, 0.0f, 0.0f, 0.0007f, 0.0818f, 0.0f}, {0.2437f, 0.2132f, 0.0842f, 0.0011f}};
-	inline constexpr RobotParameters kUR5{
-		UR5, {0.0746f, 0.0703f, 0.0f, 0.0f, 0.0397f, 0.0829f, 0.0f}, {0.4251f, 0.3922f, 0.0456f, 0.0492f}};
-	inline constexpr RobotParameters kUR10{
-		UR10, {0.109f, 0.10122f, 0.01945f, -0.00661f, 0.0584f, 0.09372f, 0.0f}, {0.6121f, 0.5722f, 0.0573f, 0.0584f}};
+	inline constexpr RobotParameters kUR3{.type = UR3,
+										  .d = {0.1089f, 0.1115f, 0.0f, 0.0f, 0.0007f, 0.0818f, 0.0f},
+										  .a = {0.2437f, 0.2132f, 0.0842f, 0.0011f}};
+	inline constexpr RobotParameters kUR5{.type = UR5,
+										  .d = {0.0746f, 0.0703f, 0.0f, 0.0f, 0.0397f, 0.0829f, 0.0f},
+										  .a = {0.4251f, 0.3922f, 0.0456f, 0.0492f}};
+	inline constexpr RobotParameters kUR10{.type = UR10,
+										   .d = {0.109f, 0.10122f, 0.01945f, -0.00661f, 0.0584f, 0.09372f, 0.0f},
+										   .a = {0.6121f, 0.5722f, 0.0573f, 0.0584f}};
 
 	/// <summary>
 	/// Returns the DH parameters for a given UR model. Unknown values fall back to UR10.
@@ -46,9 +49,11 @@ namespace universalRobots
 			return kUR3;
 		case UR5:
 			return kUR5;
-		case UR10:
+		// Explicit UR10 case plus a defensive fallback for out-of-range values
+		// intentionally return the same thing.
+		case UR10: // NOLINT(bugprone-branch-clone)
 			return kUR10;
-		default:
+		default: // NOLINT(bugprone-branch-clone)
 			return kUR10;
 		}
 	}

--- a/include/ur_kinematics/robot_parameters.h
+++ b/include/ur_kinematics/robot_parameters.h
@@ -12,7 +12,9 @@ namespace universalRobots
 	/// </summary>
 	enum URtype : unsigned int
 	{
-		UR3, UR5, UR10 // 0, 1, 2
+		UR3,
+		UR5,
+		UR10 // 0, 1, 2
 	};
 
 	/// <summary>
@@ -26,9 +28,12 @@ namespace universalRobots
 		std::array<float, 4> a;
 	};
 
-	inline constexpr RobotParameters kUR3 { UR3,  { 0.1089f, 0.1115f, 0.0f, 0.0f, 0.0007f, 0.0818f, 0.0f }, { 0.2437f, 0.2132f, 0.0842f, 0.0011f } };
-	inline constexpr RobotParameters kUR5 { UR5,  { 0.0746f, 0.0703f, 0.0f, 0.0f, 0.0397f, 0.0829f, 0.0f }, { 0.4251f, 0.3922f, 0.0456f, 0.0492f } };
-	inline constexpr RobotParameters kUR10{ UR10, { 0.109f, 0.10122f, 0.01945f, -0.00661f, 0.0584f, 0.09372f, 0.0f }, { 0.6121f, 0.5722f, 0.0573f, 0.0584f } };
+	inline constexpr RobotParameters kUR3{
+		UR3, {0.1089f, 0.1115f, 0.0f, 0.0f, 0.0007f, 0.0818f, 0.0f}, {0.2437f, 0.2132f, 0.0842f, 0.0011f}};
+	inline constexpr RobotParameters kUR5{
+		UR5, {0.0746f, 0.0703f, 0.0f, 0.0f, 0.0397f, 0.0829f, 0.0f}, {0.4251f, 0.3922f, 0.0456f, 0.0492f}};
+	inline constexpr RobotParameters kUR10{
+		UR10, {0.109f, 0.10122f, 0.01945f, -0.00661f, 0.0584f, 0.09372f, 0.0f}, {0.6121f, 0.5722f, 0.0573f, 0.0584f}};
 
 	/// <summary>
 	/// Returns the DH parameters for a given UR model. Unknown values fall back to UR10.
@@ -37,10 +42,14 @@ namespace universalRobots
 	{
 		switch (type)
 		{
-		case UR3:  return kUR3;
-		case UR5:  return kUR5;
-		case UR10: return kUR10;
-		default:   return kUR10;
+		case UR3:
+			return kUR3;
+		case UR5:
+			return kUR5;
+		case UR10:
+			return kUR10;
+		default:
+			return kUR10;
 		}
 	}
 

--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -4,6 +4,7 @@
 
 #include <iosfwd>
 #include <array>
+#include <algorithm>
 #include <Eigen/Dense>
 #include "robot_parameters.h"
 #include <stdexcept>
@@ -31,11 +32,17 @@ namespace universalRobots
 
 		pose() = default;
 
+		// Public constructor kept as plain positional floats to match existing call
+		// sites; splitting into named pos/euler types would be an API-breaking
+		// redesign out of scope here.
+		// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 		pose(float pos1, float pos2, float pos3, float eulerAngles1, float eulerAngles2, float eulerAngles3)
 			: m_pos{pos1, pos2, pos3}, m_eulerAngles{eulerAngles1, eulerAngles2, eulerAngles3}
 		{
 		}
 
+		// Same rationale as above.
+		// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 		pose(const float (&pos)[3], const float (&eulerAngles)[3])
 			: m_pos{pos[0], pos[1], pos[2]}, m_eulerAngles{eulerAngles[0], eulerAngles[1], eulerAngles[2]}
 		{
@@ -48,17 +55,20 @@ namespace universalRobots
 		{
 		}
 
-		pose divideByConst(float constant) const
+		[[nodiscard]] pose divideByConst(float constant) const
 		{
-			return pose(m_pos[0] / constant, m_pos[1] / constant, m_pos[2] / constant, m_eulerAngles[0] / constant,
-						m_eulerAngles[1] / constant, m_eulerAngles[2] / constant);
+			return {m_pos[0] / constant,		 m_pos[1] / constant,		  m_pos[2] / constant,
+					m_eulerAngles[0] / constant, m_eulerAngles[1] / constant, m_eulerAngles[2] / constant};
 		}
 
-		pose subtract(const pose& other) const
+		[[nodiscard]] pose subtract(const pose& other) const
 		{
-			return pose(m_pos[0] - other.m_pos[0], m_pos[1] - other.m_pos[1], m_pos[2] - other.m_pos[2],
-						m_eulerAngles[0] - other.m_eulerAngles[0], m_eulerAngles[1] - other.m_eulerAngles[1],
-						m_eulerAngles[2] - other.m_eulerAngles[2]);
+			return {m_pos[0] - other.m_pos[0],
+					m_pos[1] - other.m_pos[1],
+					m_pos[2] - other.m_pos[2],
+					m_eulerAngles[0] - other.m_eulerAngles[0],
+					m_eulerAngles[1] - other.m_eulerAngles[1],
+					m_eulerAngles[2] - other.m_eulerAngles[2]};
 		}
 
 		pose operator/(float constant) const
@@ -77,7 +87,7 @@ namespace universalRobots
 	/// </summary>
 	struct joint
 	{
-		pose m_jointPose = {};
+		pose m_jointPose;
 		float m_jointValue = 0.0f;
 	};
 
@@ -129,12 +139,9 @@ namespace universalRobots
 			std::array<std::array<float, m_numDoF>, m_numIkSol> solutions;
 			/// false where the geometric solution does not exist
 			std::array<bool, m_numIkSol> valid;
-			bool anyValid() const
+			[[nodiscard]] bool anyValid() const
 			{
-				for (bool v : valid)
-					if (v)
-						return true;
-				return false;
+				return std::ranges::any_of(valid, [](bool isValid) { return isValid; });
 			}
 		};
 
@@ -189,7 +196,7 @@ namespace universalRobots
 
 	  public:
 		UR(URtype robotType = UR10, bool endEffector = false, float endEffectorDimension = 0.0f);
-		URtype getRobotType() const;
+		[[nodiscard]] URtype getRobotType() const;
 		/// Precondition: every joint value must be finite and in [-2π, 2π].
 		/// Throws std::invalid_argument otherwise.
 		[[nodiscard]] pose forwardKinematics(const JointVector& targetJointVal);
@@ -197,7 +204,7 @@ namespace universalRobots
 		/// Returns true iff inverseKinematics(targetPose).anyValid().
 		[[nodiscard]] bool isPoseReachable(const pose& targetPose);
 		pose generateRandomReachablePose();
-		[[nodiscard]] bool isSolutionValid(const std::array<float, m_numDoF>& ikSolution) const;
+		[[nodiscard]] static bool isSolutionValid(const std::array<float, m_numDoF>& ikSolution);
 		friend std::ostream& operator<<(std::ostream& stream, const universalRobots::UR& robot);
 		friend std::ostream& operator<<(std::ostream& stream, universalRobots::URtype type);
 
@@ -205,10 +212,10 @@ namespace universalRobots
 		void setMDHmatrix();
 		void setRobotType(URtype type);
 		void setTheta(const JointVector& jointVal);
-		const float* getTransZ() const;
-		const float* getTransX() const;
-		float getTheta(int ix) const;
-		pose getTipPose() const;
+		[[nodiscard]] const float* getTransZ() const;
+		[[nodiscard]] const float* getTransX() const;
+		[[nodiscard]] float getTheta(int ix) const;
+		[[nodiscard]] pose getTipPose() const;
 	};
 
 	std::ostream& operator<<(std::ostream& stream, universalRobots::URtype type);

--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -136,7 +136,7 @@ namespace universalRobots
 		/// </summary>
 		struct IkSolutions
 		{
-			std::array<std::array<float, m_numDoF>, m_numIkSol> solutions;
+			std::array<std::array<float, m_numDoF>, m_numIkSol> solutions = {};
 			/// false where the geometric solution does not exist
 			std::array<bool, m_numIkSol> valid = {};
 			[[nodiscard]] bool anyValid() const

--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -184,8 +184,11 @@ namespace universalRobots
 		/// <summary>
 		/// This boolean indicates whether a tool is/isnt attached to the robot.
 		/// Must be specified in the constructor, if not default is false.
+		/// Currently stored but not read anywhere (endEffectorDimension alone drives
+		/// forwardKinematics); kept for API/ABI stability rather than removed, since
+		/// that's a behavior question out of scope for a lint-only change.
 		/// </summary>
-		bool m_endEffector = false;
+		[[maybe_unused]] bool m_endEffector = false;
 
 		/// <summary>
 		/// Modified Denavit-Hartenberg parameters matrix (9x4)

--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -26,28 +26,39 @@ namespace universalRobots
 	/// </summary>
 	struct pose
 	{
-		float m_pos[3] = {}; // x y z (meters)
+		float m_pos[3] = {};		 // x y z (meters)
 		float m_eulerAngles[3] = {}; // alpha beta gamma (radians)
 
 		pose() = default;
 
 		pose(float pos1, float pos2, float pos3, float eulerAngles1, float eulerAngles2, float eulerAngles3)
-			: m_pos{ pos1, pos2, pos3 }, m_eulerAngles{ eulerAngles1, eulerAngles2, eulerAngles3 } {}
+			: m_pos{pos1, pos2, pos3}, m_eulerAngles{eulerAngles1, eulerAngles2, eulerAngles3}
+		{
+		}
 
-		pose(const float(&pos)[3], const float(&eulerAngles)[3])
-			: m_pos{ pos[0],  pos[1],  pos[2] }, m_eulerAngles{ eulerAngles[0], eulerAngles[1], eulerAngles[2] } {}
+		pose(const float (&pos)[3], const float (&eulerAngles)[3])
+			: m_pos{pos[0], pos[1], pos[2]}, m_eulerAngles{eulerAngles[0], eulerAngles[1], eulerAngles[2]}
+		{
+		}
 
-		pose(const float(&pos)[3], const Eigen::Matrix3f& rotationMatrix)
-			: m_pos{ pos[0],  pos[1],  pos[2] }, m_eulerAngles{ rotationMatrix.eulerAngles(1, 2, 0).z(), rotationMatrix.eulerAngles(1, 2, 0).y(), rotationMatrix.eulerAngles(1, 2, 0).x() } {}
+		pose(const float (&pos)[3], const Eigen::Matrix3f& rotationMatrix)
+			: m_pos{pos[0], pos[1], pos[2]},
+			  m_eulerAngles{rotationMatrix.eulerAngles(1, 2, 0).z(), rotationMatrix.eulerAngles(1, 2, 0).y(),
+							rotationMatrix.eulerAngles(1, 2, 0).x()}
+		{
+		}
 
 		pose divideByConst(float constant) const
 		{
-			return pose(m_pos[0]/ constant, m_pos[1] / constant, m_pos[2] / constant, m_eulerAngles[0] / constant, m_eulerAngles[1] / constant, m_eulerAngles[2] / constant );
+			return pose(m_pos[0] / constant, m_pos[1] / constant, m_pos[2] / constant, m_eulerAngles[0] / constant,
+						m_eulerAngles[1] / constant, m_eulerAngles[2] / constant);
 		}
 
 		pose subtract(const pose& other) const
 		{
-			return pose(m_pos[0] - other.m_pos[0], m_pos[1] - other.m_pos[1], m_pos[2] - other.m_pos[2], m_eulerAngles[0] - other.m_eulerAngles[0], m_eulerAngles[1] - other.m_eulerAngles[1], m_eulerAngles[2] - other.m_eulerAngles[2]);
+			return pose(m_pos[0] - other.m_pos[0], m_pos[1] - other.m_pos[1], m_pos[2] - other.m_pos[2],
+						m_eulerAngles[0] - other.m_eulerAngles[0], m_eulerAngles[1] - other.m_eulerAngles[1],
+						m_eulerAngles[2] - other.m_eulerAngles[2]);
 		}
 
 		pose operator/(float constant) const
@@ -59,7 +70,6 @@ namespace universalRobots
 		{
 			return subtract(other);
 		}
-
 	};
 
 	/// <summary>
@@ -70,34 +80,33 @@ namespace universalRobots
 		pose m_jointPose = {};
 		float m_jointValue = 0.0f;
 	};
-	
+
 	/// <summary>
 	/// Implements 'UR robot type' object.
 	/// </summary>
 	class UR
 	{
-	public:
-		
+	  public:
 		/// <summary>
 		/// Number of Degrees of Freedom is always 6 for all URs.
 		/// </summary>
 		static constexpr unsigned int m_numDoF = 6;
-		
+
 		/// <summary>
 		/// Number of translations in the z-axis is always 7 (this includes a translation for the end-effector).
 		/// </summary>
-		static constexpr unsigned int m_numTransZ = 7; 
-		
+		static constexpr unsigned int m_numTransZ = 7;
+
 		/// <summary>
 		/// Number of translations in the x-axis is always 4.
 		/// </summary>
 		static constexpr unsigned int m_numTransX = 4;
-		
+
 		/// <summary>
 		/// Number of frames is pre-defined (according to the MDH convention it is 9).
 		/// </summary>
 		static constexpr unsigned int m_numReferenceFrames = 9;
-		
+
 		/// <summary>
 		/// Number of inverse kinematics solutions for a UR is 8.
 		/// </summary>
@@ -123,38 +132,38 @@ namespace universalRobots
 			bool anyValid() const
 			{
 				for (bool v : valid)
-					if (v) return true;
+					if (v)
+						return true;
 				return false;
 			}
 		};
 
-	private:
-
+	  private:
 		/// <summary>
 		/// Robot type/name UR 3, 5, or 10.
 		/// </summary>
 		/// <returns>0, 1, 2</returns>
 		URtype m_type = UR10;
-		
+
 		/// <summary>
 		/// d - translation (meters) in the z-axis (the last translation d[6] is for an end-effector).
-		/// d_i is a nomeclature convention. 
+		/// d_i is a nomeclature convention.
 		/// </summary>
 		std::array<float, m_numTransZ> m_d = kUR10.d;
-		
+
 		/// <summary>
 		/// a - translation (meters) in the x-axis.
 		/// a_i is a nomeclature convention.
 		/// </summary>
 		std::array<float, m_numTransX> m_a = kUR10.a;
-		
+
 		/// <summary>
 		/// Position, Euler Angles, and Value of the robot's joints. {x, y, z} {alpha, beta, gamma} {jointValue}
 		/// </summary>
 		joint m_jointState[m_numDoF] = {};
 
 		// Create an array of (individual) transformation matrices iTi+1 / i-1Ti
-		
+
 		/// <summary>
 		/// Array of (individual) transformation matrices iTi+1 / i-1Ti
 		/// </summary>
@@ -178,7 +187,7 @@ namespace universalRobots
 		/// </summary>
 		Eigen::Matrix<float, m_numReferenceFrames, 4> m_MDHmatrix;
 
-	public:
+	  public:
 		UR(URtype robotType = UR10, bool endEffector = false, float endEffectorDimension = 0.0f);
 		URtype getRobotType() const;
 		/// Precondition: every joint value must be finite and in [-2π, 2π].
@@ -189,9 +198,10 @@ namespace universalRobots
 		[[nodiscard]] bool isPoseReachable(const pose& targetPose);
 		pose generateRandomReachablePose();
 		[[nodiscard]] bool isSolutionValid(const std::array<float, m_numDoF>& ikSolution) const;
-		friend std::ostream& operator <<(std::ostream& stream, const universalRobots::UR& robot);
-		friend std::ostream& operator <<(std::ostream& stream, universalRobots::URtype type);
-	private:
+		friend std::ostream& operator<<(std::ostream& stream, const universalRobots::UR& robot);
+		friend std::ostream& operator<<(std::ostream& stream, universalRobots::URtype type);
+
+	  private:
 		void setMDHmatrix();
 		void setRobotType(URtype type);
 		void setTheta(const JointVector& jointVal);
@@ -201,8 +211,8 @@ namespace universalRobots
 		pose getTipPose() const;
 	};
 
-	std::ostream& operator <<(std::ostream& stream, universalRobots::URtype type);
+	std::ostream& operator<<(std::ostream& stream, universalRobots::URtype type);
 
-	std::ostream& operator <<(std::ostream& stream, const universalRobots::UR& robot);
+	std::ostream& operator<<(std::ostream& stream, const universalRobots::UR& robot);
 
-} // namespace universalRobots 
+} // namespace universalRobots

--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -138,7 +138,7 @@ namespace universalRobots
 		{
 			std::array<std::array<float, m_numDoF>, m_numIkSol> solutions;
 			/// false where the geometric solution does not exist
-			std::array<bool, m_numIkSol> valid;
+			std::array<bool, m_numIkSol> valid = {};
 			[[nodiscard]] bool anyValid() const
 			{
 				return std::ranges::any_of(valid, [](bool isValid) { return isValid; });
@@ -215,6 +215,10 @@ namespace universalRobots
 		[[nodiscard]] const float* getTransZ() const;
 		[[nodiscard]] const float* getTransX() const;
 		[[nodiscard]] float getTheta(int ix) const;
+		// `pose` is 6 floats (24 bytes), trivially copyable; a const-reference
+		// return would couple the caller to this object's lifetime for no
+		// measurable performance win.
+		// cppcheck-suppress returnByReference
 		[[nodiscard]] pose getTipPose() const;
 	};
 

--- a/src/math_utils.cpp
+++ b/src/math_utils.cpp
@@ -4,32 +4,29 @@
 #include <ur_kinematics/ur_kinematics.h>
 #include <numbers>
 
-
 namespace universalRobots
 {
 	float rad(float degree)
 	{
-		return (degree * std::numbers::pi_v<float> / 180);// C++20
-	   //return (degree * PI / 180); //non-compiler dependant
+		return (degree * std::numbers::pi_v<float> / 180); // C++20
+														   // return (degree * PI / 180); //non-compiler dependant
 	}
 
 	float deg(float rad)
 	{
-		return (rad * 180 / std::numbers::pi_v<float>);// C++20
-	   //return (rad * 180 / PI); //non-compiler dependant
+		return (rad * 180 / std::numbers::pi_v<float>); // C++20
+														// return (rad * 180 / PI); //non-compiler dependant
 	}
-
 
 	Eigen::Matrix4f calcTransformationMatrix(const Eigen::RowVector4f& DHparams)
 	{
 		Eigen::Matrix4f individualTransformationMatrix;
 		individualTransformationMatrix << cos(DHparams[3]), -sin(DHparams[3]), 0, DHparams[1],
-			(sin(DHparams[3]) * cos(DHparams[0])), (cos(DHparams[3]) * cos(DHparams[0])), -sin(DHparams[0]), (-sin(DHparams[0]) * DHparams[2]),
-			(sin(DHparams[3]) * sin(DHparams[0])), (cos(DHparams[3]) * sin(DHparams[0])), cos(DHparams[0]), (cos(DHparams[0]) * DHparams[2]),
-			0, 0, 0, 1;
+			(sin(DHparams[3]) * cos(DHparams[0])), (cos(DHparams[3]) * cos(DHparams[0])), -sin(DHparams[0]),
+			(-sin(DHparams[0]) * DHparams[2]), (sin(DHparams[3]) * sin(DHparams[0])),
+			(cos(DHparams[3]) * sin(DHparams[0])), cos(DHparams[0]), (cos(DHparams[0]) * DHparams[2]), 0, 0, 0, 1;
 
 		return individualTransformationMatrix;
 	}
-
 
 } // namespace universalRobots

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -205,6 +205,15 @@ namespace universalRobots
 	/// </summary>
 	/// <param name="targetTipPose"></param>
 	/// <param name="outIkSols"></param>
+	// This geometric solver mixes double-returning math functions (acos, atan2, sqrt,
+	// pow, ...) with float state throughout; the narrowing conversions are inherent to
+	// the algorithm, not bugs (see task 04f: even seemingly-neutral rewrites here have
+	// shifted golden values via extra rounding steps near singularities), so the
+	// warning is suppressed for the whole function rather than edited away site-by-site.
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#endif
 	UR::IkSolutions UR::inverseKinematics(const pose& targetTipPose)
 	{
 		IkSolutions outIkSols = {};
@@ -395,6 +404,9 @@ namespace universalRobots
 
 		return outIkSols;
 	}
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 	bool UR::isPoseReachable(const pose& targetPose)
 	{
@@ -416,7 +428,7 @@ namespace universalRobots
 
 		for (unsigned int i = 0; i < m_numDoF; i++)
 		{
-			randomTargetJointValue[i] = universalRobots::rad(distrib(gen));
+			randomTargetJointValue[i] = universalRobots::rad(static_cast<float>(distrib(gen)));
 		}
 
 		return forwardKinematics(randomTargetJointValue);

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -15,10 +15,7 @@ namespace
 	// Membership test for the small frame/solution index sets below.
 	template <std::size_t N> constexpr bool contains(const std::array<unsigned int, N>& set, unsigned int value)
 	{
-		for (const unsigned int element : set)
-			if (element == value)
-				return true;
-		return false;
+		return std::ranges::any_of(set, [value](unsigned int element) { return element == value; });
 	}
 
 	// Of the 9 Modified-DH reference frames, these are the ones whose general
@@ -167,7 +164,7 @@ namespace universalRobots
 		pose tipPose = {};
 		for (unsigned int i = 0; i < m_numReferenceFrames; i++)
 		{
-			if (!i)
+			if (i == 0)
 				m_generalTransformationMatrices[0] = m_individualTransformationMatrices[0];
 			else
 				m_generalTransformationMatrices[i] =
@@ -361,7 +358,7 @@ namespace universalRobots
 				// Computing theta4.
 				Eigen::Matrix4f T_12 = universalRobots::calcTransformationMatrix(
 					Eigen::RowVector4f(-std::numbers::pi_v<float> / 2, 0.0f, m_d[1],
-									   outIkSols.solutions[i][1] - std::numbers::pi_v<float> / 2));
+									   outIkSols.solutions[i][1] - (std::numbers::pi_v<float> / 2)));
 				Eigen::Matrix4f T_23 = universalRobots::calcTransformationMatrix(
 					Eigen::RowVector4f(0.0f, m_a[0], m_d[2], outIkSols.solutions[i][2]));
 				Eigen::Matrix4f T_03 = T_01 * T_12 * T_23;
@@ -384,7 +381,7 @@ namespace universalRobots
 				// Computing theta4.
 				Eigen::Matrix4f T_12 = universalRobots::calcTransformationMatrix(
 					Eigen::RowVector4f(-std::numbers::pi_v<float> / 2, 0.0f, m_d[1],
-									   outIkSols.solutions[i][1] - std::numbers::pi_v<float> / 2));
+									   outIkSols.solutions[i][1] - (std::numbers::pi_v<float> / 2)));
 				Eigen::Matrix4f T_23 = universalRobots::calcTransformationMatrix(
 					Eigen::RowVector4f(0.0f, m_a[0], m_d[2], outIkSols.solutions[i][2]));
 				Eigen::Matrix4f T_03 = T_01 * T_12 * T_23;
@@ -430,7 +427,7 @@ namespace universalRobots
 	/// </summary>
 	/// <param name="ikSolution"></param>
 	/// <returns>bool</returns>
-	bool UR::isSolutionValid(const std::array<float, m_numDoF>& ikSolution) const
+	bool UR::isSolutionValid(const std::array<float, m_numDoF>& ikSolution)
 	{
 		for (unsigned int i = 0; i < m_numDoF; i++)
 		{
@@ -474,84 +471,81 @@ namespace universalRobots
 	/// <returns>stream</returns>
 	std::ostream& operator<<(std::ostream& stream, const universalRobots::UR& robot)
 	{
-		stream << "Robot type: " << robot.m_type << std::endl
-			   << "Number of DoFs: " << robot.m_numDoF << std::endl
+		stream << "Robot type: " << robot.m_type << '\n'
+			   << "Number of DoFs: " << UR::m_numDoF << '\n'
 			   << "Link dimensions\n"
 			   << "Translations in the z-axis (meters):\n";
-		for (unsigned int i = 0; i < robot.m_numTransZ; i++)
-			stream << "d" << i + 1 << ": " << robot.m_d[i] << std::endl;
+		for (unsigned int i = 0; i < UR::m_numTransZ; i++)
+			stream << "d" << i + 1 << ": " << robot.m_d[i] << '\n';
 		stream << "Translations in the x-axis (meters):\n";
-		for (unsigned int i = 0; i < robot.m_numTransX; i++)
-			stream << "a" << i + 2 << ": " << robot.m_a[i] << std::endl;
+		for (unsigned int i = 0; i < UR::m_numTransX; i++)
+			stream << "a" << i + 2 << ": " << robot.m_a[i] << '\n';
 		stream << "Joint values (degrees):\n";
-		for (unsigned int i = 0; i < robot.m_numDoF; i++)
-			stream << "Theta" << i + 1 << ": " << universalRobots::deg(robot.getTheta(i)) << std::endl;
+		for (unsigned int i = 0; i < UR::m_numDoF; i++)
+			stream << "Theta" << i + 1 << ": " << universalRobots::deg(robot.getTheta(i)) << '\n';
 		stream << "Tip pose:\n";
 		const pose tipPose = robot.getTipPose();
 		stream << "x " << tipPose.m_pos[0] << " y " << tipPose.m_pos[1] << " z " << tipPose.m_pos[2]
 			   << " (meters)\nalpha " << universalRobots::deg(tipPose.m_eulerAngles[0]) << " beta "
 			   << universalRobots::deg(tipPose.m_eulerAngles[1]) << " gamma "
-			   << universalRobots::deg(tipPose.m_eulerAngles[2]) << " (degrees)" << std::endl;
+			   << universalRobots::deg(tipPose.m_eulerAngles[2]) << " (degrees)" << '\n';
 		stream << "Individual Transformation Matrices:\n";
 		unsigned int counter = 0;
-		for (unsigned int i = 0; i < robot.m_numReferenceFrames; i++)
+		for (unsigned int i = 0; i < UR::m_numReferenceFrames; i++)
 		{
 			if (i == 0 || i == 1 || i == 2 || i == 3 || i == 8)
 			{
-				stream << counter << "T" << counter + 1 << std::endl
-					   << robot.m_individualTransformationMatrices[i] << std::endl;
+				stream << counter << "T" << counter + 1 << '\n' << robot.m_individualTransformationMatrices[i] << '\n';
 				counter++;
 			}
 			else
 			{
 				if (i == 4)
-					stream << counter << "T" << counter << "'" << std::endl
-						   << robot.m_individualTransformationMatrices[i] << std::endl;
+					stream << counter << "T" << counter << "'" << '\n'
+						   << robot.m_individualTransformationMatrices[i] << '\n';
 				if (i == 5)
 				{
-					stream << counter << "'T" << counter + 1 << std::endl
-						   << robot.m_individualTransformationMatrices[i] << std::endl;
+					stream << counter << "'T" << counter + 1 << '\n'
+						   << robot.m_individualTransformationMatrices[i] << '\n';
 					counter++;
 				}
 				if (i == 6)
-					stream << counter << "T" << counter << "'" << std::endl
-						   << robot.m_individualTransformationMatrices[i] << std::endl;
+					stream << counter << "T" << counter << "'" << '\n'
+						   << robot.m_individualTransformationMatrices[i] << '\n';
 				if (i == 7)
 				{
-					stream << counter << "'T" << counter + 1 << std::endl
-						   << robot.m_individualTransformationMatrices[i] << std::endl;
+					stream << counter << "'T" << counter + 1 << '\n'
+						   << robot.m_individualTransformationMatrices[i] << '\n';
 					counter++;
 				}
 			}
 		}
 		stream << "General Transformation Matrices:\n";
 		counter = 1;
-		for (unsigned int i = 0; i < robot.m_numReferenceFrames; i++)
+		for (unsigned int i = 0; i < UR::m_numReferenceFrames; i++)
 		{
 			if (i == 0 || i == 1 || i == 2 || i == 3 || i == 5 || i == 7 || i == 8)
 			{
-				stream << "0T" << counter << std::endl << robot.m_generalTransformationMatrices[i] << std::endl;
+				stream << "0T" << counter << '\n' << robot.m_generalTransformationMatrices[i] << '\n';
 				counter++;
 			}
 
 			else
 			{
 				if (i == 4)
-					stream << "0T" << counter - 1 << "'" << std::endl
-						   << robot.m_generalTransformationMatrices[i] << std::endl;
+					stream << "0T" << counter - 1 << "'" << '\n' << robot.m_generalTransformationMatrices[i] << '\n';
 				if (i == 6)
-					stream << "0T" << counter - 1 << "'" << std::endl
-						   << robot.m_generalTransformationMatrices[i] << std::endl;
+					stream << "0T" << counter - 1 << "'" << '\n' << robot.m_generalTransformationMatrices[i] << '\n';
 			}
 		}
 		stream << "Joint poses: {x, y, z} metres {alpha, beta, gamma} degrees\n";
-		for (unsigned int i = 0; i < robot.m_numDoF; i++)
+		for (unsigned int i = 0; i < UR::m_numDoF; i++)
 			stream << "J" << i + 1 << ": {" << robot.m_jointState[i].m_jointPose.m_pos[0] << ", "
 				   << robot.m_jointState[i].m_jointPose.m_pos[1] << ", " << robot.m_jointState[i].m_jointPose.m_pos[2]
 				   << "}"
 				   << " {" << universalRobots::deg(robot.m_jointState[i].m_jointPose.m_eulerAngles[0]) << ", "
 				   << universalRobots::deg(robot.m_jointState[i].m_jointPose.m_eulerAngles[1]) << ", "
-				   << universalRobots::deg(robot.m_jointState[i].m_jointPose.m_eulerAngles[2]) << "}" << std::endl;
+				   << universalRobots::deg(robot.m_jointState[i].m_jointPose.m_eulerAngles[2]) << "}" << '\n';
 
 		return stream;
 	}

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -13,8 +13,7 @@
 namespace
 {
 	// Membership test for the small frame/solution index sets below.
-	template <std::size_t N>
-	constexpr bool contains(const std::array<unsigned int, N>& set, unsigned int value)
+	template <std::size_t N> constexpr bool contains(const std::array<unsigned int, N>& set, unsigned int value)
 	{
 		for (const unsigned int element : set)
 			if (element == value)
@@ -25,16 +24,16 @@ namespace
 	// Of the 9 Modified-DH reference frames, these are the ones whose general
 	// transform yields a joint pose (frames 0..5 -> joints 1..6) or the tip pose
 	// (frame 8). Frames 4 and 6 are the intermediate 4'/5' frames with no pose.
-	constexpr std::array<unsigned int, 7> kPoseBearingFrames{ 0, 1, 2, 3, 5, 7, 8 };
+	constexpr std::array<unsigned int, 7> kPoseBearingFrames{0, 1, 2, 3, 5, 7, 8};
 
 	// The IK solutions whose wrist is in the "up" configuration; these take
 	// +acos for theta5, the others take -acos.
-	constexpr std::array<unsigned int, 4> kWristUpSolutionIndices{ 0, 1, 4, 5 };
+	constexpr std::array<unsigned int, 4> kWristUpSolutionIndices{0, 1, 4, 5};
 
 	// Solutions alternate elbow configuration; these (odd) indices take the
 	// theta3 = pi - psi branch, the even indices take theta3 = pi + psi.
-	constexpr std::array<unsigned int, 4> kSecondElbowSolutionIndices{ 1, 3, 5, 7 };
-}
+	constexpr std::array<unsigned int, 4> kSecondElbowSolutionIndices{1, 3, 5, 7};
+} // namespace
 
 namespace universalRobots
 {
@@ -56,7 +55,7 @@ namespace universalRobots
 		m_d[m_numTransZ - 1] = endEffectorDimension;
 		setMDHmatrix();
 	}
-	
+
 	/// <summary>
 	/// setRobotType
 	/// </summary>
@@ -71,17 +70,17 @@ namespace universalRobots
 	///	</summary>
 	void UR::setMDHmatrix()
 	{
-		m_MDHmatrix << 0.0f,					0.0f,		m_d[0],			m_jointState[0].m_jointValue,					// 0T1
-						universalRobots::rad(-90),		0.0f,		m_d[1],			m_jointState[1].m_jointValue + universalRobots::rad(-90) ,// 1T2
-						0.0f,					m_a[0],		m_d[2],			m_jointState[2].m_jointValue,					// 2T3
-						0.0f,					m_a[1],		m_d[3],			m_jointState[3].m_jointValue,					// 3T4
-						0.0f,					m_a[2],		m_d[4],			universalRobots::rad(90) ,				// 4T4'
-						universalRobots::rad(90),		0.0f,		0.0f,			m_jointState[4].m_jointValue,					// 4'T5
-						universalRobots::rad(-90),		0.0f,		0.0f,			universalRobots::rad(-90) ,				// 5T5'
-						0.0f,					m_a[3],		m_d[5],			m_jointState[5].m_jointValue,					// 5'T6
-						0.0f,					0,			m_d[6],			0 ;								// 6T7
+		m_MDHmatrix << 0.0f, 0.0f, m_d[0], m_jointState[0].m_jointValue,									   // 0T1
+			universalRobots::rad(-90), 0.0f, m_d[1], m_jointState[1].m_jointValue + universalRobots::rad(-90), // 1T2
+			0.0f, m_a[0], m_d[2], m_jointState[2].m_jointValue,												   // 2T3
+			0.0f, m_a[1], m_d[3], m_jointState[3].m_jointValue,												   // 3T4
+			0.0f, m_a[2], m_d[4], universalRobots::rad(90),													   // 4T4'
+			universalRobots::rad(90), 0.0f, 0.0f, m_jointState[4].m_jointValue,								   // 4'T5
+			universalRobots::rad(-90), 0.0f, 0.0f, universalRobots::rad(-90),								   // 5T5'
+			0.0f, m_a[3], m_d[5], m_jointState[5].m_jointValue,												   // 5'T6
+			0.0f, 0, m_d[6], 0;																				   // 6T7
 	}
-	
+
 	/// <summary>
 	/// setTheta
 	/// </summary>
@@ -91,7 +90,7 @@ namespace universalRobots
 		for (unsigned int i = 0; i < m_numDoF; i++)
 			m_jointState[i].m_jointValue = jointVal[i];
 	}
-	
+
 	/// <summary>
 	/// Returns the enum URtype. Used for printing purposes.
 	/// </summary>
@@ -100,7 +99,7 @@ namespace universalRobots
 	{
 		return m_type;
 	}
-	
+
 	/// <summary>
 	/// Returns the values of the z-axis translations (d array). Used for printing purposes.
 	/// </summary>
@@ -109,7 +108,7 @@ namespace universalRobots
 	{
 		return m_d.data();
 	}
-	
+
 	/// <summary>
 	/// Returns the values of the x-axis translations (a array). Used for printing purposes.
 	/// </summary>
@@ -118,7 +117,7 @@ namespace universalRobots
 	{
 		return m_a.data();
 	}
-	
+
 	/// <summary>
 	/// Returns the robot's current joint values. Used for printing purposes.
 	/// </summary>
@@ -127,16 +126,16 @@ namespace universalRobots
 	{
 		return m_jointState[ix].m_jointValue;
 	}
-	
+
 	/// <summary>
 	/// Returns the robot's current tip pose. Used for printing purposes.
 	/// </summary>
 	/// <returns>m_tipPose</returns>
 	pose UR::getTipPose() const
 	{
-		return m_jointState[m_numDoF-1].m_jointPose;
+		return m_jointState[m_numDoF - 1].m_jointPose;
 	}
-	
+
 	/// <summary>
 	/// Receives an array of target joint values and computes the pose of the robot's tip.
 	/// </summary>
@@ -162,17 +161,17 @@ namespace universalRobots
 		for (unsigned int i = 0; i < m_numReferenceFrames; i++)
 			m_individualTransformationMatrices[i] = universalRobots::calcTransformationMatrix(m_MDHmatrix.row(i));
 
-		// Determine the general transformation matrices.		
+		// Determine the general transformation matrices.
 		Eigen::Matrix3f rotationMatrix;
 		unsigned int currentJoint = 0;
 		pose tipPose = {};
 		for (unsigned int i = 0; i < m_numReferenceFrames; i++)
 		{
-			if(!i)
+			if (!i)
 				m_generalTransformationMatrices[0] = m_individualTransformationMatrices[0];
 			else
-				m_generalTransformationMatrices[i] = m_generalTransformationMatrices[i - 1] * m_individualTransformationMatrices[i];
-
+				m_generalTransformationMatrices[i] =
+					m_generalTransformationMatrices[i - 1] * m_individualTransformationMatrices[i];
 
 			// Obtaining the joint pose
 			// Since we have more reference frames than joints only some represent a joint pose
@@ -180,11 +179,14 @@ namespace universalRobots
 			if (contains(kPoseBearingFrames, i))
 			{
 				// 0T1 1 // 1T2 2// 2T3 3// 3T4 4// 4T4' // 4'T5 5// 5T5' // 5'T6 6// 6T7
-				rotationMatrix << m_generalTransformationMatrices[i](0, 0), m_generalTransformationMatrices[i](0, 1), m_generalTransformationMatrices[i](0, 2),
-					m_generalTransformationMatrices[i](1, 0), m_generalTransformationMatrices[i](1, 1), m_generalTransformationMatrices[i](1, 2),
-					m_generalTransformationMatrices[i](2, 0), m_generalTransformationMatrices[i](2, 1), m_generalTransformationMatrices[i](2, 2);
+				rotationMatrix << m_generalTransformationMatrices[i](0, 0), m_generalTransformationMatrices[i](0, 1),
+					m_generalTransformationMatrices[i](0, 2), m_generalTransformationMatrices[i](1, 0),
+					m_generalTransformationMatrices[i](1, 1), m_generalTransformationMatrices[i](1, 2),
+					m_generalTransformationMatrices[i](2, 0), m_generalTransformationMatrices[i](2, 1),
+					m_generalTransformationMatrices[i](2, 2);
 
-				float position[3] = { m_generalTransformationMatrices[i](0, 3), m_generalTransformationMatrices[i](1, 3), m_generalTransformationMatrices[i](2, 3) };
+				float position[3] = {m_generalTransformationMatrices[i](0, 3), m_generalTransformationMatrices[i](1, 3),
+									 m_generalTransformationMatrices[i](2, 3)};
 
 				// Tip pose
 				if (i == 8)
@@ -197,16 +199,16 @@ namespace universalRobots
 			}
 		}
 
-		//return m_jointState[m_numDoF-1].m_jointPose;
+		// return m_jointState[m_numDoF-1].m_jointPose;
 		return tipPose;
 	}
-	
+
 	/// <summary>
 	/// Computes the eight inverse kinematics solutions for a given tip pose.
 	/// </summary>
 	/// <param name="targetTipPose"></param>
 	/// <param name="outIkSols"></param>
-	UR::IkSolutions UR::inverseKinematics(const pose &targetTipPose)
+	UR::IkSolutions UR::inverseKinematics(const pose& targetTipPose)
 	{
 		IkSolutions outIkSols = {};
 		outIkSols.valid.fill(true); // start optimistic; mark false at each failed acos site
@@ -216,39 +218,45 @@ namespace universalRobots
 		Eigen::Matrix4f T_07 = Eigen::Matrix4f::Identity(); // 0T7
 
 		// Get translation matrix.
-		const Eigen::Vector3f translation = { targetTipPose.m_pos[0], targetTipPose.m_pos[1], targetTipPose.m_pos[2] };
+		const Eigen::Vector3f translation = {targetTipPose.m_pos[0], targetTipPose.m_pos[1], targetTipPose.m_pos[2]};
 
 		// Calculate rotation matrix.
 		Eigen::Matrix3f rotation;
-		rotation = Eigen::AngleAxisf(targetTipPose.m_eulerAngles[0], Eigen::Vector3f::UnitX())
-				*Eigen::AngleAxisf(targetTipPose.m_eulerAngles[1], Eigen::Vector3f::UnitY())
-				*Eigen::AngleAxisf(targetTipPose.m_eulerAngles[2], Eigen::Vector3f::UnitZ());
+		rotation = Eigen::AngleAxisf(targetTipPose.m_eulerAngles[0], Eigen::Vector3f::UnitX()) *
+				   Eigen::AngleAxisf(targetTipPose.m_eulerAngles[1], Eigen::Vector3f::UnitY()) *
+				   Eigen::AngleAxisf(targetTipPose.m_eulerAngles[2], Eigen::Vector3f::UnitZ());
 
 		T_07.block<3, 3>(0, 0) = rotation;
 		T_07.block<3, 1>(0, 3) = translation;
 
 		// Computing theta1.
-		const Eigen::Matrix<float, 1, 4> P_05 = T_07 * Eigen::Matrix<float, 1, 4>(0.0f, 0.0f, -m_d[5] - m_d[6], 1.0f).transpose(); // 0P5 position of reference frame {5} in relation to {0}
+		const Eigen::Matrix<float, 1, 4> P_05 =
+			T_07 * Eigen::Matrix<float, 1, 4>(0.0f, 0.0f, -m_d[5] - m_d[6], 1.0f)
+					   .transpose(); // 0P5 position of reference frame {5} in relation to {0}
 		const float theta1_psi = atan2(P_05(0, 1), P_05(0, 0));
 
-		// There are two possible solutions for theta1, that depend on whether the shoulder joint (joint 2) is left or right.
-		// acos site 1: theta1_phi — if |arg| > 1+eps, all 8 solutions are invalid.
-		// NOTE: the domain check below uses its own copy of the acos argument rather than a
-		// shared named variable. Routing the in-domain acos() call through a materialized
-		// float intermediate (instead of the original inline expression) forces an extra
-		// float32 rounding step that, right at this near-singular domain edge (|arg|≈1, where
-		// d(acos)/dx diverges), measurably shifts the result vs the golden baseline. Keeping the
-		// acos() call on the untouched inline expression preserves bit-identical valid-row output.
-		const bool phi_inDomain = std::abs((m_d[1] + m_d[2] + m_d[3] + m_d[4]) / (sqrt( pow(P_05(0, 1), 2) + pow(P_05(0, 0), 2) ) )) <= 1.0 + kAcosEps;
+		// There are two possible solutions for theta1, that depend on whether the shoulder joint (joint 2) is left or
+		// right. acos site 1: theta1_phi — if |arg| > 1+eps, all 8 solutions are invalid. NOTE: the domain check below
+		// uses its own copy of the acos argument rather than a shared named variable. Routing the in-domain acos() call
+		// through a materialized float intermediate (instead of the original inline expression) forces an extra float32
+		// rounding step that, right at this near-singular domain edge (|arg|≈1, where d(acos)/dx diverges), measurably
+		// shifts the result vs the golden baseline. Keeping the acos() call on the untouched inline expression
+		// preserves bit-identical valid-row output.
+		const bool phi_inDomain = std::abs((m_d[1] + m_d[2] + m_d[3] + m_d[4]) /
+										   (sqrt(pow(P_05(0, 1), 2) + pow(P_05(0, 0), 2)))) <= 1.0 + kAcosEps;
 		if (!phi_inDomain)
 			outIkSols.valid.fill(false);
-		const float theta1_phi = phi_inDomain
-			? acos(std::clamp((m_d[1] + m_d[2] + m_d[3] + m_d[4]) / (sqrt( pow(P_05(0, 1), 2) + pow(P_05(0, 0), 2) ) ), -1.0, 1.0))
-			: std::numeric_limits<float>::quiet_NaN();
+		const float theta1_phi =
+			phi_inDomain
+				? acos(std::clamp((m_d[1] + m_d[2] + m_d[3] + m_d[4]) / (sqrt(pow(P_05(0, 1), 2) + pow(P_05(0, 0), 2))),
+								  -1.0, 1.0))
+				: std::numeric_limits<float>::quiet_NaN();
 
-		for (int i = -4; i < int (m_numIkSol) - 4 ; i++)
+		for (int i = -4; i < int(m_numIkSol) - 4; i++)
 		{
-			outIkSols.solutions[i + 4][0] = (std::numbers::pi_v<float> / 2 + theta1_psi + (i < 0 ? 1 : -1)* theta1_phi) - std::numbers::pi_v<float>; // (i < 0 ? 1 : -1) first 4 theta1 values have positive phi
+			outIkSols.solutions[i + 4][0] =
+				(std::numbers::pi_v<float> / 2 + theta1_psi + (i < 0 ? 1 : -1) * theta1_phi) -
+				std::numbers::pi_v<float>; // (i < 0 ? 1 : -1) first 4 theta1 values have positive phi
 		}
 
 		Eigen::Matrix4f T_06 = T_07;
@@ -257,8 +265,9 @@ namespace universalRobots
 		for (unsigned int i = 0; i < m_numIkSol; i++)
 		{
 			// Computing theta5.
-			 Eigen::Matrix4f T_01 = universalRobots::calcTransformationMatrix(Eigen::RowVector4f{ 0.0f, 0.0f, m_d[0], outIkSols.solutions[i][0] }); // Knowing theta1 it is possible to know 0T1
-			 Eigen::Matrix4f T_16 = T_01.inverse() * T_06; // 1T6 = 1T0 * 0T6
+			Eigen::Matrix4f T_01 = universalRobots::calcTransformationMatrix(Eigen::RowVector4f{
+				0.0f, 0.0f, m_d[0], outIkSols.solutions[i][0]}); // Knowing theta1 it is possible to know 0T1
+			Eigen::Matrix4f T_16 = T_01.inverse() * T_06;		 // 1T6 = 1T0 * 0T6
 
 			// acos site 2: theta5 — if |arg| > 1+eps, solution i is invalid.
 			const float t5_arg = (T_16(1, 3) - (m_d[1] + m_d[2] + m_d[3] + m_d[4])) / m_d[5];
@@ -293,42 +302,50 @@ namespace universalRobots
 			const bool nearPiSingularity = std::abs(std::abs(theta5) - std::numbers::pi_v<float>) < kPiSingularityEps;
 
 			// Computing theta6.
-			if (theta5 == 0 || theta5 == 2 * std::numbers::pi_v<float> || nearPiSingularity) // If theta5 is at the singularity (0 or +-pi).
+			if (theta5 == 0 || theta5 == 2 * std::numbers::pi_v<float> ||
+				nearPiSingularity)				  // If theta5 is at the singularity (0 or +-pi).
 				outIkSols.solutions[i][5] = 0.0f; // Wrist singularity: theta6 pinned to 0 by convention.
 			else
 			{
 				const float sinTheta5 = sin(theta5);
-				outIkSols.solutions[i][5] = std::numbers::pi_v<float> / 2 + atan2(-T_16.inverse()(1, 1) / sinTheta5, T_16.inverse()(0, 1) / sinTheta5);
+				outIkSols.solutions[i][5] = std::numbers::pi_v<float> / 2 +
+											atan2(-T_16.inverse()(1, 1) / sinTheta5, T_16.inverse()(0, 1) / sinTheta5);
 			}
-
 
 			// Computing theta3, theta2, and theta4.
 
 			// T_45 = T_44'*T_4'5
-			 Eigen::Matrix4f T_44_ = universalRobots::calcTransformationMatrix(Eigen::RowVector4f (0.0f, m_a[2], m_d[4], std::numbers::pi_v<float> / 2));
-			 Eigen::Matrix4f T_4_5 = universalRobots::calcTransformationMatrix(Eigen::RowVector4f(std::numbers::pi_v<float> / 2, 0.0f, 0.0f, outIkSols.solutions[i][4]));
-			 Eigen::Matrix4f T_45 = T_44_ * T_4_5;
+			Eigen::Matrix4f T_44_ = universalRobots::calcTransformationMatrix(
+				Eigen::RowVector4f(0.0f, m_a[2], m_d[4], std::numbers::pi_v<float> / 2));
+			Eigen::Matrix4f T_4_5 = universalRobots::calcTransformationMatrix(
+				Eigen::RowVector4f(std::numbers::pi_v<float> / 2, 0.0f, 0.0f, outIkSols.solutions[i][4]));
+			Eigen::Matrix4f T_45 = T_44_ * T_4_5;
 
 			// T_56 = T_55'*T_5'6
-			 Eigen::Matrix4f T_55_ = universalRobots::calcTransformationMatrix(Eigen::RowVector4f(-std::numbers::pi_v<float> / 2, 0.0f, 0.0f, -std::numbers::pi_v<float> / 2));
-			 Eigen::Matrix4f T_5_6 = universalRobots::calcTransformationMatrix(Eigen::RowVector4f(0.0f, m_a[3], m_d[5], outIkSols.solutions[i][5]));
-			 Eigen::Matrix4f T_56 = T_55_ * T_5_6;
+			Eigen::Matrix4f T_55_ = universalRobots::calcTransformationMatrix(
+				Eigen::RowVector4f(-std::numbers::pi_v<float> / 2, 0.0f, 0.0f, -std::numbers::pi_v<float> / 2));
+			Eigen::Matrix4f T_5_6 = universalRobots::calcTransformationMatrix(
+				Eigen::RowVector4f(0.0f, m_a[3], m_d[5], outIkSols.solutions[i][5]));
+			Eigen::Matrix4f T_56 = T_55_ * T_5_6;
 
-			 Eigen::Matrix4f T_46 = T_45 * T_56;
-			 Eigen::Matrix4f T_14 = T_16 * T_46.inverse();
+			Eigen::Matrix4f T_46 = T_45 * T_56;
+			Eigen::Matrix4f T_14 = T_16 * T_46.inverse();
 
-			 float P_14_xz = sqrtf( pow(T_14(0, 3), 2) + pow(T_14(2, 3), 2));
+			float P_14_xz = sqrtf(pow(T_14(0, 3), 2) + pow(T_14(2, 3), 2));
 
 			// acos site 3: theta3_psi — if |arg| > 1+eps, solution i is invalid.
 			// See the site-1 note above: acos() is called on the untouched inline expression
 			// (clamped with double bounds) rather than a materialized float intermediate, to
 			// avoid an extra precision-losing rounding step right at this near-singular edge.
-			const bool psi_inDomain = std::abs((pow(P_14_xz, 2) - pow(m_a[1], 2) - pow(m_a[0], 2)) / (-2 * m_a[0] * m_a[1])) <= 1.0 + kAcosEps;
+			const bool psi_inDomain = std::abs((pow(P_14_xz, 2) - pow(m_a[1], 2) - pow(m_a[0], 2)) /
+											   (-2 * m_a[0] * m_a[1])) <= 1.0 + kAcosEps;
 			if (!psi_inDomain)
 				outIkSols.valid[i] = false;
-			const float theta3_psi = psi_inDomain
-				? acos(std::clamp((pow(P_14_xz, 2) - pow(m_a[1], 2) - pow(m_a[0], 2)) / (-2 * m_a[0] * m_a[1]), -1.0, 1.0))
-				: std::numeric_limits<float>::quiet_NaN();
+			const float theta3_psi =
+				psi_inDomain
+					? acos(std::clamp((pow(P_14_xz, 2) - pow(m_a[1], 2) - pow(m_a[0], 2)) / (-2 * m_a[0] * m_a[1]),
+									  -1.0, 1.0))
+					: std::numeric_limits<float>::quiet_NaN();
 
 			// Elbow up or down
 			if (contains(kSecondElbowSolutionIndices, i))
@@ -339,16 +356,20 @@ namespace universalRobots
 				if (outIkSols.solutions[i][2] > std::numbers::pi_v<float>)
 					outIkSols.solutions[i][2] = outIkSols.solutions[i][2] - std::numbers::pi_v<float> * 2;
 				// Computing theta2.
-				outIkSols.solutions[i][1] = std::numbers::pi_v<float> / 2 - atan2(T_14(2, 3), T_14(0, 3)) + asin((m_a[1] * sin(-theta3_psi)) / P_14_xz);
+				outIkSols.solutions[i][1] = std::numbers::pi_v<float> / 2 - atan2(T_14(2, 3), T_14(0, 3)) +
+											asin((m_a[1] * sin(-theta3_psi)) / P_14_xz);
 				// Computing theta4.
-				 Eigen::Matrix4f T_12 = universalRobots::calcTransformationMatrix(Eigen::RowVector4f(-std::numbers::pi_v<float> / 2, 0.0f, m_d[1], outIkSols.solutions[i][1] - std::numbers::pi_v<float> / 2));
-				 Eigen::Matrix4f T_23 = universalRobots::calcTransformationMatrix(Eigen::RowVector4f(0.0f, m_a[0], m_d[2], outIkSols.solutions[i][2]));
-				 Eigen::Matrix4f T_03 = T_01 * T_12 * T_23;
+				Eigen::Matrix4f T_12 = universalRobots::calcTransformationMatrix(
+					Eigen::RowVector4f(-std::numbers::pi_v<float> / 2, 0.0f, m_d[1],
+									   outIkSols.solutions[i][1] - std::numbers::pi_v<float> / 2));
+				Eigen::Matrix4f T_23 = universalRobots::calcTransformationMatrix(
+					Eigen::RowVector4f(0.0f, m_a[0], m_d[2], outIkSols.solutions[i][2]));
+				Eigen::Matrix4f T_03 = T_01 * T_12 * T_23;
 
-				 Eigen::Matrix4f T_36 = T_03.inverse() * T_06;
-				 Eigen::Matrix4f T_34 = T_36 * T_46.inverse();
+				Eigen::Matrix4f T_36 = T_03.inverse() * T_06;
+				Eigen::Matrix4f T_34 = T_36 * T_46.inverse();
 
-				 outIkSols.solutions[i][3] = atan2(T_34(1, 0), T_34(0, 0));
+				outIkSols.solutions[i][3] = atan2(T_34(1, 0), T_34(0, 0));
 			}
 			else
 			{
@@ -356,18 +377,22 @@ namespace universalRobots
 				outIkSols.solutions[i][2] = std::numbers::pi_v<float> + theta3_psi;
 				// Masking theta3 for CoppeliaSim(invert value for ang > 180).
 				if (outIkSols.solutions[i][2] > std::numbers::pi_v<float>)
-					outIkSols.solutions[i][2] = outIkSols.solutions[i][2] - std::numbers::pi_v<float> *2;
+					outIkSols.solutions[i][2] = outIkSols.solutions[i][2] - std::numbers::pi_v<float> * 2;
 				// Computing theta2.
-				outIkSols.solutions[i][1] = std::numbers::pi_v<float> / 2 - atan2(T_14(2, 3), T_14(0, 3)) + asin(m_a[1] * sin(theta3_psi) / P_14_xz);
+				outIkSols.solutions[i][1] = std::numbers::pi_v<float> / 2 - atan2(T_14(2, 3), T_14(0, 3)) +
+											asin(m_a[1] * sin(theta3_psi) / P_14_xz);
 				// Computing theta4.
-				 Eigen::Matrix4f T_12 = universalRobots::calcTransformationMatrix(Eigen::RowVector4f(-std::numbers::pi_v<float> / 2, 0.0f, m_d[1], outIkSols.solutions[i][1] - std::numbers::pi_v<float> / 2));
-				 Eigen::Matrix4f T_23 = universalRobots::calcTransformationMatrix(Eigen::RowVector4f(0.0f, m_a[0], m_d[2], outIkSols.solutions[i][2]));
-				 Eigen::Matrix4f T_03 = T_01 * T_12 * T_23;
+				Eigen::Matrix4f T_12 = universalRobots::calcTransformationMatrix(
+					Eigen::RowVector4f(-std::numbers::pi_v<float> / 2, 0.0f, m_d[1],
+									   outIkSols.solutions[i][1] - std::numbers::pi_v<float> / 2));
+				Eigen::Matrix4f T_23 = universalRobots::calcTransformationMatrix(
+					Eigen::RowVector4f(0.0f, m_a[0], m_d[2], outIkSols.solutions[i][2]));
+				Eigen::Matrix4f T_03 = T_01 * T_12 * T_23;
 
-				 Eigen::Matrix4f T_36 = T_03.inverse() * T_06;
-				 Eigen::Matrix4f T_34 = T_36 * T_46.inverse();
+				Eigen::Matrix4f T_36 = T_03.inverse() * T_06;
+				Eigen::Matrix4f T_34 = T_36 * T_46.inverse();
 
-				 outIkSols.solutions[i][3] = atan2(T_34(1, 0), T_34(0, 0));
+				outIkSols.solutions[i][3] = atan2(T_34(1, 0), T_34(0, 0));
 			}
 		}
 
@@ -383,7 +408,7 @@ namespace universalRobots
 	/// Generates a valid tip pose by running forward kinematics with random target joint values.
 	/// </summary>
 	/// <returns>randomValidTargetPose</returns>
-	pose UR::generateRandomReachablePose() 
+	pose UR::generateRandomReachablePose()
 	{
 		//// https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution
 		std::random_device rd;
@@ -398,10 +423,7 @@ namespace universalRobots
 		}
 
 		return forwardKinematics(randomTargetJointValue);
-
-		 
 	}
-
 
 	/// <summary>
 	/// Checks whether an inverse-kinematics solution is valid (contains no NaN entries).
@@ -412,7 +434,7 @@ namespace universalRobots
 	{
 		for (unsigned int i = 0; i < m_numDoF; i++)
 		{
-			if(std::isnan(ikSolution[i]))
+			if (std::isnan(ikSolution[i]))
 				return false;
 		}
 
@@ -425,7 +447,7 @@ namespace universalRobots
 	/// <param name="stream"></param>
 	/// <param name="type"></param>
 	/// <returns>stream</returns>
-	std::ostream& operator <<(std::ostream& stream, universalRobots::URtype type)
+	std::ostream& operator<<(std::ostream& stream, universalRobots::URtype type)
 	{
 		switch (type)
 		{
@@ -450,11 +472,12 @@ namespace universalRobots
 	/// <param name="stream"></param>
 	/// <param name="robot"></param>
 	/// <returns>stream</returns>
-	std::ostream& operator <<(std::ostream& stream, const universalRobots::UR& robot)
+	std::ostream& operator<<(std::ostream& stream, const universalRobots::UR& robot)
 	{
 		stream << "Robot type: " << robot.m_type << std::endl
-			<< "Number of DoFs: " << robot.m_numDoF << std::endl
-			<< "Link dimensions\n" << "Translations in the z-axis (meters):\n";
+			   << "Number of DoFs: " << robot.m_numDoF << std::endl
+			   << "Link dimensions\n"
+			   << "Translations in the z-axis (meters):\n";
 		for (unsigned int i = 0; i < robot.m_numTransZ; i++)
 			stream << "d" << i + 1 << ": " << robot.m_d[i] << std::endl;
 		stream << "Translations in the x-axis (meters):\n";
@@ -465,31 +488,38 @@ namespace universalRobots
 			stream << "Theta" << i + 1 << ": " << universalRobots::deg(robot.getTheta(i)) << std::endl;
 		stream << "Tip pose:\n";
 		const pose tipPose = robot.getTipPose();
-		stream << "x " << tipPose.m_pos[0] << " y " << tipPose.m_pos[1] << " z " << tipPose.m_pos[2] << " (meters)\nalpha "
-				<< universalRobots::deg(tipPose.m_eulerAngles[0]) << " beta " << universalRobots::deg(tipPose.m_eulerAngles[1]) << " gamma " << universalRobots::deg(tipPose.m_eulerAngles[2]) << " (degrees)" << std::endl;
+		stream << "x " << tipPose.m_pos[0] << " y " << tipPose.m_pos[1] << " z " << tipPose.m_pos[2]
+			   << " (meters)\nalpha " << universalRobots::deg(tipPose.m_eulerAngles[0]) << " beta "
+			   << universalRobots::deg(tipPose.m_eulerAngles[1]) << " gamma "
+			   << universalRobots::deg(tipPose.m_eulerAngles[2]) << " (degrees)" << std::endl;
 		stream << "Individual Transformation Matrices:\n";
 		unsigned int counter = 0;
 		for (unsigned int i = 0; i < robot.m_numReferenceFrames; i++)
 		{
 			if (i == 0 || i == 1 || i == 2 || i == 3 || i == 8)
 			{
-				stream << counter << "T" << counter + 1 << std::endl << robot.m_individualTransformationMatrices[i] << std::endl;
+				stream << counter << "T" << counter + 1 << std::endl
+					   << robot.m_individualTransformationMatrices[i] << std::endl;
 				counter++;
-			}	
+			}
 			else
 			{
-				if(i == 4)
-					stream << counter << "T" << counter << "'" << std::endl << robot.m_individualTransformationMatrices[i] << std::endl;
+				if (i == 4)
+					stream << counter << "T" << counter << "'" << std::endl
+						   << robot.m_individualTransformationMatrices[i] << std::endl;
 				if (i == 5)
-				{					
-					stream << counter << "'T" << counter + 1 << std::endl << robot.m_individualTransformationMatrices[i] << std::endl;
+				{
+					stream << counter << "'T" << counter + 1 << std::endl
+						   << robot.m_individualTransformationMatrices[i] << std::endl;
 					counter++;
 				}
 				if (i == 6)
-					stream << counter << "T" <<  counter << "'" <<std::endl << robot.m_individualTransformationMatrices[i] << std::endl;
+					stream << counter << "T" << counter << "'" << std::endl
+						   << robot.m_individualTransformationMatrices[i] << std::endl;
 				if (i == 7)
 				{
-					stream << counter << "'T" << counter + 1 << std::endl << robot.m_individualTransformationMatrices[i] << std::endl;
+					stream << counter << "'T" << counter + 1 << std::endl
+						   << robot.m_individualTransformationMatrices[i] << std::endl;
 					counter++;
 				}
 			}
@@ -503,21 +533,27 @@ namespace universalRobots
 				stream << "0T" << counter << std::endl << robot.m_generalTransformationMatrices[i] << std::endl;
 				counter++;
 			}
-				
+
 			else
 			{
 				if (i == 4)
-					stream << "0T" << counter - 1 << "'" << std::endl << robot.m_generalTransformationMatrices[i] << std::endl;
+					stream << "0T" << counter - 1 << "'" << std::endl
+						   << robot.m_generalTransformationMatrices[i] << std::endl;
 				if (i == 6)
-					stream << "0T" << counter - 1 << "'" << std::endl << robot.m_generalTransformationMatrices[i] << std::endl;
+					stream << "0T" << counter - 1 << "'" << std::endl
+						   << robot.m_generalTransformationMatrices[i] << std::endl;
 			}
 		}
 		stream << "Joint poses: {x, y, z} metres {alpha, beta, gamma} degrees\n";
 		for (unsigned int i = 0; i < robot.m_numDoF; i++)
-			stream << "J" << i + 1	<< ": {" << robot.m_jointState[i].m_jointPose.m_pos[0]  << ", " << robot.m_jointState[i].m_jointPose.m_pos[1] << ", " << robot.m_jointState[i].m_jointPose.m_pos[2] << "}"
-									<< " {" << universalRobots::deg(robot.m_jointState[i].m_jointPose.m_eulerAngles[0]) << ", " << universalRobots::deg(robot.m_jointState[i].m_jointPose.m_eulerAngles[1]) << ", " << universalRobots::deg(robot.m_jointState[i].m_jointPose.m_eulerAngles[2]) << "}" << std::endl;
+			stream << "J" << i + 1 << ": {" << robot.m_jointState[i].m_jointPose.m_pos[0] << ", "
+				   << robot.m_jointState[i].m_jointPose.m_pos[1] << ", " << robot.m_jointState[i].m_jointPose.m_pos[2]
+				   << "}"
+				   << " {" << universalRobots::deg(robot.m_jointState[i].m_jointPose.m_eulerAngles[0]) << ", "
+				   << universalRobots::deg(robot.m_jointState[i].m_jointPose.m_eulerAngles[1]) << ", "
+				   << universalRobots::deg(robot.m_jointState[i].m_jointPose.m_eulerAngles[2]) << "}" << std::endl;
 
 		return stream;
 	}
 
-} // namespace universalRobots 
+} // namespace universalRobots

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ set(GOLDEN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/golden")
 # --- Golden data generator (run once; NOT registered with CTest) ------------------
 add_executable(golden_generator golden_generator.cpp)
 target_include_directories(golden_generator PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(golden_generator PRIVATE ur_kinematics)
+target_link_libraries(golden_generator PRIVATE ur_kinematics project_warnings)
 target_compile_definitions(golden_generator PRIVATE
     GOLDEN_DIR="${GOLDEN_DIR}"
     GIT_COMMIT="${GOLDEN_GIT_COMMIT}"
@@ -48,7 +48,7 @@ add_executable(ur_kinematics_tests
     test_validation.cpp
 )
 target_include_directories(ur_kinematics_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(ur_kinematics_tests PRIVATE ur_kinematics GTest::gtest_main)
+target_link_libraries(ur_kinematics_tests PRIVATE ur_kinematics GTest::gtest_main project_warnings)
 target_compile_definitions(ur_kinematics_tests PRIVATE
     GOLDEN_DIR="${GOLDEN_DIR}"
 )

--- a/tests/golden_config.hpp
+++ b/tests/golden_config.hpp
@@ -22,9 +22,9 @@ namespace goldencfg
 	inline const std::vector<ModelSpec>& models()
 	{
 		static const std::vector<ModelSpec> m = {
-			{ universalRobots::URtype::UR3,  "UR3"  },
-			{ universalRobots::URtype::UR5,  "UR5"  },
-			{ universalRobots::URtype::UR10, "UR10" },
+			{universalRobots::URtype::UR3, "UR3"},
+			{universalRobots::URtype::UR5, "UR5"},
+			{universalRobots::URtype::UR10, "UR10"},
 		};
 		return m;
 	}
@@ -39,8 +39,8 @@ namespace goldencfg
 	inline const std::vector<EeSpec>& endEffectorDims()
 	{
 		static const std::vector<EeSpec> e = {
-			{ 0.00f, "d0"   },
-			{ 0.15f, "d015" },
+			{0.00f, "d0"},
+			{0.15f, "d015"},
 		};
 		return e;
 	}
@@ -52,8 +52,8 @@ namespace goldencfg
 	inline constexpr int kIkUnreachableCount = 10;
 
 	// Tolerances (documented per-suite; also written into each JSON header).
-	inline constexpr double kFkTolerance = 1e-5;        // abs, meters / radians
-	inline constexpr double kIkTolerance = 1e-4;        // abs, radians per joint
+	inline constexpr double kFkTolerance = 1e-5; // abs, meters / radians
+	inline constexpr double kIkTolerance = 1e-4; // abs, radians per joint
 	// 1e-4: cross-platform float determinism floor for the 6-DOF IK chain; matches rev1/main.
 	inline constexpr double kRoundTripPosTolerance = 1e-4; // abs, meters
 
@@ -66,4 +66,4 @@ namespace goldencfg
 	{
 		return "ik_" + model + ".json";
 	}
-}
+} // namespace goldencfg

--- a/tests/golden_generator.cpp
+++ b/tests/golden_generator.cpp
@@ -60,7 +60,8 @@ namespace
 		for (int i = 0; i < 6; ++i)
 		{
 			s += f(v[i]);
-			if (i != 5) s += ", ";
+			if (i != 5)
+				s += ", ";
 		}
 		s += "]";
 		return s;
@@ -68,8 +69,7 @@ namespace
 
 	std::string poseArr(const universalRobots::pose& p)
 	{
-		float v[6] = { p.m_pos[0], p.m_pos[1], p.m_pos[2],
-					   p.m_eulerAngles[0], p.m_eulerAngles[1], p.m_eulerAngles[2] };
+		float v[6] = {p.m_pos[0], p.m_pos[1], p.m_pos[2], p.m_eulerAngles[0], p.m_eulerAngles[1], p.m_eulerAngles[2]};
 		return arr6(v);
 	}
 
@@ -78,21 +78,21 @@ namespace
 	std::vector<NamedJoints> buildFkInputs()
 	{
 		std::vector<NamedJoints> in;
-		auto add = [&](std::string n, Joints j) { in.push_back({ std::move(n), j }); };
+		auto add = [&](std::string n, Joints j) { in.push_back({std::move(n), j}); };
 
 		// The demo fixture from Application/src/main.cpp (UR5 {23,345,78,66,77,12} deg).
-		add("main_demo", { universalRobots::rad(23), universalRobots::rad(345), universalRobots::rad(78),
-						   universalRobots::rad(66), universalRobots::rad(77), universalRobots::rad(12) });
+		add("main_demo", {universalRobots::rad(23), universalRobots::rad(345), universalRobots::rad(78),
+						  universalRobots::rad(66), universalRobots::rad(77), universalRobots::rad(12)});
 
 		// Hand-picked edge cases.
-		add("zeros", { 0, 0, 0, 0, 0, 0 });
-		add("all_+pi_2", { kPi / 2, kPi / 2, kPi / 2, kPi / 2, kPi / 2, kPi / 2 });
-		add("all_-pi_2", { -kPi / 2, -kPi / 2, -kPi / 2, -kPi / 2, -kPi / 2, -kPi / 2 });
-		add("all_+pi", { kPi, kPi, kPi, kPi, kPi, kPi });
-		add("all_-pi", { -kPi, -kPi, -kPi, -kPi, -kPi, -kPi });
-		add("theta5_zero", { 0.3f, 0.3f, 0.3f, 0.3f, 0.0f, 0.3f });
-		add("theta5_+1e-4", { 0.3f, 0.3f, 0.3f, 0.3f, 1e-4f, 0.3f });
-		add("theta5_-1e-4", { 0.3f, 0.3f, 0.3f, 0.3f, -1e-4f, 0.3f });
+		add("zeros", {0, 0, 0, 0, 0, 0});
+		add("all_+pi_2", {kPi / 2, kPi / 2, kPi / 2, kPi / 2, kPi / 2, kPi / 2});
+		add("all_-pi_2", {-kPi / 2, -kPi / 2, -kPi / 2, -kPi / 2, -kPi / 2, -kPi / 2});
+		add("all_+pi", {kPi, kPi, kPi, kPi, kPi, kPi});
+		add("all_-pi", {-kPi, -kPi, -kPi, -kPi, -kPi, -kPi});
+		add("theta5_zero", {0.3f, 0.3f, 0.3f, 0.3f, 0.0f, 0.3f});
+		add("theta5_+1e-4", {0.3f, 0.3f, 0.3f, 0.3f, 1e-4f, 0.3f});
+		add("theta5_-1e-4", {0.3f, 0.3f, 0.3f, 0.3f, -1e-4f, 0.3f});
 
 		// Seeded random draws, uniform in [-2*pi, 2*pi] per joint.
 		std::mt19937 gen(goldencfg::kSeed);
@@ -100,14 +100,15 @@ namespace
 		for (int k = 0; k < goldencfg::kRandomFkCount; ++k)
 		{
 			Joints j;
-			for (float& x : j) x = dist(gen);
+			for (float& x : j)
+				x = dist(gen);
 			add("random_" + std::to_string(k), j);
 		}
 		return in;
 	}
 
-	void writeFkFile(const std::string& outDir, const goldencfg::ModelSpec& model,
-					 const goldencfg::EeSpec& ee, const std::vector<NamedJoints>& inputs)
+	void writeFkFile(const std::string& outDir, const goldencfg::ModelSpec& model, const goldencfg::EeSpec& ee,
+					 const std::vector<NamedJoints>& inputs)
 	{
 		universalRobots::UR robot(model.type, ee.dimension != 0.0f, ee.dimension);
 
@@ -147,7 +148,8 @@ namespace
 		for (int i = 0; i < 8; ++i)
 		{
 			s += arr6(sols.solutions[i].data());
-			if (i != 7) s += ", ";
+			if (i != 7)
+				s += ", ";
 		}
 		s += "]";
 		return s;
@@ -159,7 +161,8 @@ namespace
 		for (int i = 0; i < 8; ++i)
 		{
 			s += sols.valid[i] ? "true" : "false";
-			if (i != 7) s += ", ";
+			if (i != 7)
+				s += ", ";
 		}
 		s += "]";
 		return s;
@@ -169,7 +172,8 @@ namespace
 	std::string loadOldGolden(const std::string& path)
 	{
 		std::ifstream is(path, std::ios::binary);
-		if (!is) return {};
+		if (!is)
+			return {};
 		std::ostringstream ss;
 		ss << is.rdbuf();
 		return ss.str();
@@ -185,7 +189,8 @@ namespace
 		// Find "solutions": [ then parse nested arrays
 		const std::string tag = "\"solutions\": [";
 		std::size_t pos = caseLine.find(tag);
-		if (pos == std::string::npos) return vals;
+		if (pos == std::string::npos)
+			return vals;
 		pos += tag.size();
 		int idx = 0;
 		while (idx < 48 && pos < caseLine.size())
@@ -193,8 +198,17 @@ namespace
 			// skip whitespace, '[', ','
 			while (pos < caseLine.size() && (caseLine[pos] == ' ' || caseLine[pos] == '[' || caseLine[pos] == ','))
 				++pos;
-			if (pos >= caseLine.size() || caseLine[pos] == ']') { ++pos; continue; }
-			if (caseLine.substr(pos, 4) == "null") { ++pos; idx++; continue; } // NaN stays
+			if (pos >= caseLine.size() || caseLine[pos] == ']')
+			{
+				++pos;
+				continue;
+			}
+			if (caseLine.substr(pos, 4) == "null")
+			{
+				++pos;
+				idx++;
+				continue;
+			} // NaN stays
 			// parse number
 			char* end = nullptr;
 			double v = std::strtod(caseLine.c_str() + pos, &end);
@@ -203,7 +217,8 @@ namespace
 				vals[idx++] = static_cast<float>(v);
 				pos = static_cast<std::size_t>(end - caseLine.c_str());
 			}
-			else ++pos;
+			else
+				++pos;
 		}
 		return vals;
 	}
@@ -234,7 +249,7 @@ namespace
 		{
 			const universalRobots::pose tip = robot.forwardKinematics(fkInputs[c].joints);
 			const universalRobots::UR::IkSolutions sols = robot.inverseKinematics(tip);
-			cases.push_back({ "reachable_" + std::to_string(c), true, tip, sols });
+			cases.push_back({"reachable_" + std::to_string(c), true, tip, sols});
 		}
 
 		// Unreachable poses: positions far outside the workspace (10 m).
@@ -242,10 +257,14 @@ namespace
 		{
 			const float base = 10.0f + static_cast<float>(c);
 			universalRobots::pose far;
-			far.m_pos[0] = base; far.m_pos[1] = base; far.m_pos[2] = base;
-			far.m_eulerAngles[0] = 0.1f * c; far.m_eulerAngles[1] = 0.0f; far.m_eulerAngles[2] = 0.0f;
+			far.m_pos[0] = base;
+			far.m_pos[1] = base;
+			far.m_pos[2] = base;
+			far.m_eulerAngles[0] = 0.1f * c;
+			far.m_eulerAngles[1] = 0.0f;
+			far.m_eulerAngles[2] = 0.0f;
 			const universalRobots::UR::IkSolutions sols = robot.inverseKinematics(far);
-			cases.push_back({ "unreachable_" + std::to_string(c), false, far, sols });
+			cases.push_back({"unreachable_" + std::to_string(c), false, far, sols});
 		}
 
 		// --- Revision-1 valid-row assertion ---
@@ -258,31 +277,33 @@ namespace
 			{
 				const std::string caseTag = "\"name\": \"" + cases[ci].name + "\"";
 				const std::size_t cpos = rev1Text.find(caseTag);
-				if (cpos == std::string::npos) continue;
+				if (cpos == std::string::npos)
+					continue;
 
 				// Find end-of-case line (up to next '{' at column 4 or end of cases array).
 				const std::size_t lineEnd = rev1Text.find('\n', cpos);
-				const std::string caseLine = rev1Text.substr(cpos,
-					lineEnd == std::string::npos ? std::string::npos : lineEnd - cpos);
+				const std::string caseLine =
+					rev1Text.substr(cpos, lineEnd == std::string::npos ? std::string::npos : lineEnd - cpos);
 
 				const std::array<float, 48> rev1vals = parseRev1Solutions(caseLine);
 
 				for (int s = 0; s < 8; ++s)
 				{
-					if (!cases[ci].sols.valid[s]) continue; // rev2 invalid — skip
+					if (!cases[ci].sols.valid[s])
+						continue; // rev2 invalid — skip
 					for (int k = 0; k < 6; ++k)
 					{
 						const float rev1v = rev1vals[s * 6 + k];
 						const float rev2v = cases[ci].sols.solutions[s][k];
-						if (!std::isfinite(rev1v)) continue; // rev1 was NaN — newly valid row, OK
+						if (!std::isfinite(rev1v))
+							continue; // rev1 was NaN — newly valid row, OK
 						++assertChecked;
 						// Bit-identical: same float value (or within 1 ULP for compiler variation)
 						if (rev1v != rev2v)
 						{
 							std::printf("ASSERTION FAILED: %s case %s sol %d joint %d: "
 										"rev1=%.9g rev2=%.9g\n",
-										goldencfg::ikFileName(model.name).c_str(),
-										cases[ci].name.c_str(), s, k,
+										goldencfg::ikFileName(model.name).c_str(), cases[ci].name.c_str(), s, k,
 										static_cast<double>(rev1v), static_cast<double>(rev2v));
 							++assertFailed;
 						}
@@ -293,7 +314,8 @@ namespace
 						goldencfg::ikFileName(model.name).c_str(), assertChecked, assertFailed);
 			if (assertFailed > 0)
 			{
-				std::fprintf(stderr, "ERROR: revision-2 golden differs from revision-1 on shared valid rows. Aborting.\n");
+				std::fprintf(stderr,
+							 "ERROR: revision-2 golden differs from revision-1 on shared valid rows. Aborting.\n");
 				std::exit(1);
 			}
 		}
@@ -335,10 +357,10 @@ namespace
 
 		std::ofstream os(path, std::ios::binary);
 		os << header << body << "}\n";
-		std::printf("wrote %s (%d reachable + %d unreachable, rev3 with valid flags)\n",
-					path.c_str(), reach, goldencfg::kIkUnreachableCount);
+		std::printf("wrote %s (%d reachable + %d unreachable, rev3 with valid flags)\n", path.c_str(), reach,
+					goldencfg::kIkUnreachableCount);
 	}
-}
+} // namespace
 
 int main(int argc, char** argv)
 {

--- a/tests/golden_load.hpp
+++ b/tests/golden_load.hpp
@@ -30,4 +30,4 @@ namespace goldenload
 	{
 		return jsonmini::parse(readFile(name));
 	}
-}
+} // namespace goldenload

--- a/tests/json_mini.hpp
+++ b/tests/json_mini.hpp
@@ -23,7 +23,15 @@ namespace jsonmini
 
 	struct Value
 	{
-		enum class Type { Null, Bool, Number, String, Array, Object };
+		enum class Type
+		{
+			Null,
+			Bool,
+			Number,
+			String,
+			Array,
+			Object
+		};
 
 		Type type = Type::Null;
 		bool boolean = false;
@@ -32,13 +40,34 @@ namespace jsonmini
 		std::shared_ptr<Array> array;
 		std::shared_ptr<Object> object;
 
-		bool isNull() const { return type == Type::Null; }
-		float asFloat() const { return static_cast<float>(number); }
-		double asDouble() const { return number; }
-		int asInt() const { return static_cast<int>(number); }
-		bool asBool() const { return boolean; }
-		const std::string& asString() const { return string; }
-		const Array& asArray() const { return *array; }
+		bool isNull() const
+		{
+			return type == Type::Null;
+		}
+		float asFloat() const
+		{
+			return static_cast<float>(number);
+		}
+		double asDouble() const
+		{
+			return number;
+		}
+		int asInt() const
+		{
+			return static_cast<int>(number);
+		}
+		bool asBool() const
+		{
+			return boolean;
+		}
+		const std::string& asString() const
+		{
+			return string;
+		}
+		const Array& asArray() const
+		{
+			return *array;
+		}
 
 		// Object member access by key (throws if absent).
 		const Value& operator[](const std::string& key) const
@@ -50,15 +79,23 @@ namespace jsonmini
 		}
 
 		// Array element access by index.
-		const Value& operator[](std::size_t i) const { return (*array)[i]; }
+		const Value& operator[](std::size_t i) const
+		{
+			return (*array)[i];
+		}
 
-		std::size_t size() const { return array ? array->size() : 0; }
+		std::size_t size() const
+		{
+			return array ? array->size() : 0;
+		}
 	};
 
 	class Parser
 	{
-	public:
-		explicit Parser(const std::string& text) : m_text(text) {}
+	  public:
+		explicit Parser(const std::string& text) : m_text(text)
+		{
+		}
 
 		Value parse()
 		{
@@ -70,7 +107,7 @@ namespace jsonmini
 			return v;
 		}
 
-	private:
+	  private:
 		const std::string& m_text;
 		std::size_t m_pos = 0;
 
@@ -79,8 +116,14 @@ namespace jsonmini
 			throw std::runtime_error("json_mini: parse error at " + std::to_string(m_pos) + ": " + msg);
 		}
 
-		char peek() const { return m_pos < m_text.size() ? m_text[m_pos] : '\0'; }
-		char get() { return m_text[m_pos++]; }
+		char peek() const
+		{
+			return m_pos < m_text.size() ? m_text[m_pos] : '\0';
+		}
+		char get()
+		{
+			return m_text[m_pos++];
+		}
 
 		void skipWs()
 		{
@@ -106,12 +149,19 @@ namespace jsonmini
 			skipWs();
 			switch (peek())
 			{
-			case '{': return parseObject();
-			case '[': return parseArray();
-			case '"': return parseString();
-			case 't': case 'f': return parseBool();
-			case 'n': return parseNull();
-			default:  return parseNumber();
+			case '{':
+				return parseObject();
+			case '[':
+				return parseArray();
+			case '"':
+				return parseString();
+			case 't':
+			case 'f':
+				return parseBool();
+			case 'n':
+				return parseNull();
+			default:
+				return parseNumber();
 			}
 		}
 
@@ -122,7 +172,11 @@ namespace jsonmini
 			v.object = std::make_shared<Object>();
 			expect('{');
 			skipWs();
-			if (peek() == '}') { ++m_pos; return v; }
+			if (peek() == '}')
+			{
+				++m_pos;
+				return v;
+			}
 			for (;;)
 			{
 				skipWs();
@@ -135,8 +189,10 @@ namespace jsonmini
 				v.object->emplace_back(std::move(key), std::move(val));
 				skipWs();
 				const char c = get();
-				if (c == ',') continue;
-				if (c == '}') break;
+				if (c == ',')
+					continue;
+				if (c == '}')
+					break;
 				fail("expected ',' or '}' in object");
 			}
 			return v;
@@ -149,14 +205,20 @@ namespace jsonmini
 			v.array = std::make_shared<Array>();
 			expect('[');
 			skipWs();
-			if (peek() == ']') { ++m_pos; return v; }
+			if (peek() == ']')
+			{
+				++m_pos;
+				return v;
+			}
 			for (;;)
 			{
 				v.array->push_back(parseValue());
 				skipWs();
 				const char c = get();
-				if (c == ',') continue;
-				if (c == ']') break;
+				if (c == ',')
+					continue;
+				if (c == ']')
+					break;
 				fail("expected ',' or ']' in array");
 			}
 			return v;
@@ -171,21 +233,39 @@ namespace jsonmini
 				if (m_pos >= m_text.size())
 					fail("unterminated string");
 				char c = get();
-				if (c == '"') break;
+				if (c == '"')
+					break;
 				if (c == '\\')
 				{
 					char e = get();
 					switch (e)
 					{
-					case '"':  out.push_back('"'); break;
-					case '\\': out.push_back('\\'); break;
-					case '/':  out.push_back('/'); break;
-					case 'n':  out.push_back('\n'); break;
-					case 't':  out.push_back('\t'); break;
-					case 'r':  out.push_back('\r'); break;
-					case 'b':  out.push_back('\b'); break;
-					case 'f':  out.push_back('\f'); break;
-					default:   fail("unsupported escape");
+					case '"':
+						out.push_back('"');
+						break;
+					case '\\':
+						out.push_back('\\');
+						break;
+					case '/':
+						out.push_back('/');
+						break;
+					case 'n':
+						out.push_back('\n');
+						break;
+					case 't':
+						out.push_back('\t');
+						break;
+					case 'r':
+						out.push_back('\r');
+						break;
+					case 'b':
+						out.push_back('\b');
+						break;
+					case 'f':
+						out.push_back('\f');
+						break;
+					default:
+						fail("unsupported escape");
 					}
 				}
 				else
@@ -208,9 +288,18 @@ namespace jsonmini
 		{
 			Value v;
 			v.type = Value::Type::Bool;
-			if (m_text.compare(m_pos, 4, "true") == 0) { v.boolean = true; m_pos += 4; }
-			else if (m_text.compare(m_pos, 5, "false") == 0) { v.boolean = false; m_pos += 5; }
-			else fail("invalid literal");
+			if (m_text.compare(m_pos, 4, "true") == 0)
+			{
+				v.boolean = true;
+				m_pos += 4;
+			}
+			else if (m_text.compare(m_pos, 5, "false") == 0)
+			{
+				v.boolean = false;
+				m_pos += 5;
+			}
+			else
+				fail("invalid literal");
 			return v;
 		}
 
@@ -226,14 +315,23 @@ namespace jsonmini
 		Value parseNumber()
 		{
 			const std::size_t start = m_pos;
-			if (peek() == '-') ++m_pos;
-			while (std::isdigit(static_cast<unsigned char>(peek()))) ++m_pos;
-			if (peek() == '.') { ++m_pos; while (std::isdigit(static_cast<unsigned char>(peek()))) ++m_pos; }
+			if (peek() == '-')
+				++m_pos;
+			while (std::isdigit(static_cast<unsigned char>(peek())))
+				++m_pos;
+			if (peek() == '.')
+			{
+				++m_pos;
+				while (std::isdigit(static_cast<unsigned char>(peek())))
+					++m_pos;
+			}
 			if (peek() == 'e' || peek() == 'E')
 			{
 				++m_pos;
-				if (peek() == '+' || peek() == '-') ++m_pos;
-				while (std::isdigit(static_cast<unsigned char>(peek()))) ++m_pos;
+				if (peek() == '+' || peek() == '-')
+					++m_pos;
+				while (std::isdigit(static_cast<unsigned char>(peek())))
+					++m_pos;
 			}
 			if (m_pos == start)
 				fail("invalid number");
@@ -244,5 +342,8 @@ namespace jsonmini
 		}
 	};
 
-	inline Value parse(const std::string& text) { return Parser(text).parse(); }
-}
+	inline Value parse(const std::string& text)
+	{
+		return Parser(text).parse();
+	}
+} // namespace jsonmini

--- a/tests/test_golden_fk.cpp
+++ b/tests/test_golden_fk.cpp
@@ -46,7 +46,7 @@ namespace
 				EXPECT_NEAR(tip.m_eulerAngles[i], expected[i + 3].asFloat(), tol) << "euler[" << i << "]";
 		}
 	}
-}
+} // namespace
 
 TEST(GoldenFk, AllModelsAndEndEffectors)
 {

--- a/tests/test_golden_ik.cpp
+++ b/tests/test_golden_ik.cpp
@@ -21,8 +21,10 @@ namespace
 	universalRobots::pose poseFromArray(const jsonmini::Value& arr)
 	{
 		universalRobots::pose p;
-		for (int i = 0; i < 3; ++i) p.m_pos[i] = arr[i].asFloat();
-		for (int i = 0; i < 3; ++i) p.m_eulerAngles[i] = arr[i + 3].asFloat();
+		for (int i = 0; i < 3; ++i)
+			p.m_pos[i] = arr[i].asFloat();
+		for (int i = 0; i < 3; ++i)
+			p.m_eulerAngles[i] = arr[i + 3].asFloat();
 		return p;
 	}
 
@@ -39,7 +41,14 @@ namespace
 		// "valid" array was added in golden revision 2.
 		// Check if this is a rev-2 file by probing for the key (throws if absent).
 		bool hasValidFlags = false;
-		try { header["golden_revision"]; hasValidFlags = true; } catch (...) {}
+		try
+		{
+			header["golden_revision"];
+			hasValidFlags = true;
+		}
+		catch (...)
+		{
+		}
 
 		const jsonmini::Value& cases = doc["cases"];
 		ASSERT_GT(cases.size(), 0u);
@@ -70,17 +79,15 @@ namespace
 					const float actual = sols.solutions[s][k];
 					if (e.isNull())
 					{
-						EXPECT_TRUE(std::isnan(actual))
-							<< "sol " << s << " joint " << k << ": expected NaN";
+						EXPECT_TRUE(std::isnan(actual)) << "sol " << s << " joint " << k << ": expected NaN";
 						rowFinite = false;
 					}
 					else
 					{
-						EXPECT_FALSE(std::isnan(actual))
-							<< "sol " << s << " joint " << k << ": unexpected NaN";
-						EXPECT_NEAR(actual, e.asFloat(), ikTol)
-							<< "sol " << s << " joint " << k;
-						if (std::isnan(actual)) rowFinite = false;
+						EXPECT_FALSE(std::isnan(actual)) << "sol " << s << " joint " << k << ": unexpected NaN";
+						EXPECT_NEAR(actual, e.asFloat(), ikTol) << "sol " << s << " joint " << k;
+						if (std::isnan(actual))
+							rowFinite = false;
 					}
 				}
 
@@ -90,8 +97,7 @@ namespace
 					const jsonmini::Value& validArr = tc["valid"];
 					ASSERT_EQ(validArr.size(), 8u);
 					const bool goldenValid = validArr[static_cast<std::size_t>(s)].asBool();
-					EXPECT_EQ(sols.valid[s], goldenValid)
-						<< "sol " << s << " valid flag mismatch";
+					EXPECT_EQ(sols.valid[s], goldenValid) << "sol " << s << " valid flag mismatch";
 				}
 
 				// Round-trip only for reachable targets with a fully finite solution row.
@@ -105,7 +111,7 @@ namespace
 			}
 		}
 	}
-}
+} // namespace
 
 TEST(GoldenIk, AllModels)
 {
@@ -123,12 +129,16 @@ TEST(GoldenIk, UnreachableProducesNaN)
 	for (std::size_t c = 0; c < cases.size(); ++c)
 	{
 		const jsonmini::Value& tc = cases[c];
-		if (tc["reachable"].asBool()) continue;
+		if (tc["reachable"].asBool())
+			continue;
 		const jsonmini::Value& sols = tc["solutions"];
 		for (int s = 0; s < 8 && !sawUnreachableNaN; ++s)
 			for (int k = 0; k < 6; ++k)
-				if (sols[s][k].isNull()) { sawUnreachableNaN = true; break; }
+				if (sols[s][k].isNull())
+				{
+					sawUnreachableNaN = true;
+					break;
+				}
 	}
-	EXPECT_TRUE(sawUnreachableNaN)
-		<< "expected at least one NaN entry among unreachable UR5 targets";
+	EXPECT_TRUE(sawUnreachableNaN) << "expected at least one NaN entry among unreachable UR5 targets";
 }

--- a/tests/test_sanity.cpp
+++ b/tests/test_sanity.cpp
@@ -12,7 +12,7 @@ TEST(Sanity, HarnessLinks)
 TEST(Sanity, ForwardKinematicsRuns)
 {
 	universalRobots::UR robot(universalRobots::URtype::UR5);
-	const universalRobots::UR::JointVector zeros = { 0, 0, 0, 0, 0, 0 };
+	const universalRobots::UR::JointVector zeros = {0, 0, 0, 0, 0, 0};
 	const universalRobots::pose tip = robot.forwardKinematics(zeros);
 	// The zero-configuration tip must be finite.
 	for (float p : tip.m_pos)

--- a/tests/test_validation.cpp
+++ b/tests/test_validation.cpp
@@ -17,10 +17,13 @@
 
 namespace
 {
-	constexpr float kPi   = std::numbers::pi_v<float>;
-	constexpr float k2Pi  = 2.0f * kPi;
+	constexpr float kPi = std::numbers::pi_v<float>;
+	constexpr float k2Pi = 2.0f * kPi;
 
-	universalRobots::UR::JointVector zeros() { return {}; }
+	universalRobots::UR::JointVector zeros()
+	{
+		return {};
+	}
 
 	// Build a clearly reachable, well-conditioned pose (all-zero joints is a theta5≈0
 	// wrist singularity for this robot's home configuration; using a non-singular
@@ -29,9 +32,9 @@ namespace
 	universalRobots::pose reachablePose()
 	{
 		universalRobots::UR robot;
-		universalRobots::UR::JointVector joints{
-			universalRobots::rad(23), universalRobots::rad(345), universalRobots::rad(78),
-			universalRobots::rad(66), universalRobots::rad(77), universalRobots::rad(12) };
+		universalRobots::UR::JointVector joints{universalRobots::rad(23), universalRobots::rad(345),
+												universalRobots::rad(78), universalRobots::rad(66),
+												universalRobots::rad(77), universalRobots::rad(12)};
 		return robot.forwardKinematics(joints);
 	}
 } // namespace
@@ -82,7 +85,7 @@ TEST(FkValidation, AcceptsTwoPiBoundary)
 {
 	universalRobots::UR robot;
 	auto joints = zeros();
-	joints[0] =  k2Pi;
+	joints[0] = k2Pi;
 	joints[1] = -k2Pi;
 	EXPECT_NO_THROW({ (void)robot.forwardKinematics(joints); });
 }
@@ -106,7 +109,9 @@ TEST(IkValidFlags, UnreachablePoseHasNoValidSolution)
 {
 	universalRobots::UR robot;
 	universalRobots::pose far;
-	far.m_pos[0] = 10.0f; far.m_pos[1] = 10.0f; far.m_pos[2] = 10.0f;
+	far.m_pos[0] = 10.0f;
+	far.m_pos[1] = 10.0f;
+	far.m_pos[2] = 10.0f;
 	const auto sols = robot.inverseKinematics(far);
 	EXPECT_FALSE(sols.anyValid());
 	// Every solution row should be invalid.
@@ -118,14 +123,21 @@ TEST(IkValidFlags, InvalidRowsHaveNaNAngles)
 {
 	universalRobots::UR robot;
 	universalRobots::pose far;
-	far.m_pos[0] = 10.0f; far.m_pos[1] = 10.0f; far.m_pos[2] = 10.0f;
+	far.m_pos[0] = 10.0f;
+	far.m_pos[1] = 10.0f;
+	far.m_pos[2] = 10.0f;
 	const auto sols = robot.inverseKinematics(far);
 	for (int s = 0; s < 8; ++s)
 	{
-		if (sols.valid[s]) continue;
+		if (sols.valid[s])
+			continue;
 		bool hasNaN = false;
 		for (int k = 0; k < 6; ++k)
-			if (std::isnan(sols.solutions[s][k])) { hasNaN = true; break; }
+			if (std::isnan(sols.solutions[s][k]))
+			{
+				hasNaN = true;
+				break;
+			}
 		EXPECT_TRUE(hasNaN) << "invalid sol " << s << " should contain NaN";
 	}
 }
@@ -136,10 +148,10 @@ TEST(IkValidFlags, ValidRowsAreAllFinite)
 	const auto sols = robot.inverseKinematics(reachablePose());
 	for (int s = 0; s < 8; ++s)
 	{
-		if (!sols.valid[s]) continue;
+		if (!sols.valid[s])
+			continue;
 		for (int k = 0; k < 6; ++k)
-			EXPECT_TRUE(std::isfinite(sols.solutions[s][k]))
-				<< "valid sol " << s << " joint " << k << " is not finite";
+			EXPECT_TRUE(std::isfinite(sols.solutions[s][k])) << "valid sol " << s << " joint " << k << " is not finite";
 	}
 }
 
@@ -153,7 +165,9 @@ TEST(IsPoseReachable, ReturnsFalseForUnreachable)
 {
 	universalRobots::UR robot;
 	universalRobots::pose far;
-	far.m_pos[0] = 10.0f; far.m_pos[1] = 10.0f; far.m_pos[2] = 10.0f;
+	far.m_pos[0] = 10.0f;
+	far.m_pos[1] = 10.0f;
+	far.m_pos[2] = 10.0f;
 	EXPECT_FALSE(robot.isPoseReachable(far));
 }
 
@@ -171,7 +185,8 @@ namespace
 		EXPECT_TRUE(sols.anyValid());
 		for (int s = 0; s < 8; ++s)
 		{
-			if (!sols.valid[s]) continue;
+			if (!sols.valid[s])
+				continue;
 			for (int k = 0; k < 6; ++k)
 				EXPECT_TRUE(std::isfinite(sols.solutions[s][k])) << "sol " << s << " joint " << k;
 
@@ -181,7 +196,7 @@ namespace
 					<< "round-trip sol " << s << " pos[" << i << "]";
 		}
 	}
-}
+} // namespace
 
 TEST(WristSingularity, Theta5ZeroRowsAreValidAndFkConsistent)
 {
@@ -193,7 +208,7 @@ TEST(WristSingularity, Theta5ZeroRowsAreValidAndFkConsistent)
 TEST(WristSingularity, Theta5PiRowsAreValidAndFkConsistent)
 {
 	universalRobots::UR robot;
-	const universalRobots::UR::JointVector joints{ kPi, kPi, kPi, kPi, kPi, kPi }; // theta5 == pi
+	const universalRobots::UR::JointVector joints{kPi, kPi, kPi, kPi, kPi, kPi}; // theta5 == pi
 	const universalRobots::pose target = robot.forwardKinematics(joints);
 	expectValidRowsAreFkConsistent(robot, target);
 }


### PR DESCRIPTION
## Summary
- `.clang-format` (Microsoft base, Allman braces, tab indent, 120 col) applied once to `include/ src/ apps/ tests/` in a dedicated commit; `.git-blame-ignore-revs` added.
- `.clang-tidy` reconciled from #40's blanket 16-category disable to a curated `bugprone-*`/`modernize-*`/`readability-*`/`performance-*`/`cppcoreguidelines-*` set — every finding fixed in-code, `NOLINT`'d with a one-line justification, or disabled with a documented reason (see the comment block in `.clang-tidy`).
- cppcheck (`--enable=warning,performance,portability --error-exitcode=1 --inline-suppr`) wired into the existing `static-analysis.yml` workflow, alongside a new `clang-format --dry-run -Werror` step.
- Warnings-as-errors (`-Wall -Wextra -Wpedantic` / `/W4`) for `ur_kinematics`, `ur_demo`, and the test executables only, via `target_compile_options` on a `project_warnings` interface target — never global, so FetchContent'd Eigen/GoogleTest are unaffected (their include dirs are re-added as `SYSTEM` so their own header warnings don't get promoted to errors in our TUs).
- A few real bugs the new warnings/cppcheck caught along the way: uninitialized `IkSolutions::valid`, uninitialized `std::chrono::duration` accumulators in the benchmark loop, a fully-shadowed dead `tipPoseInput` in the benchmark, and `main()` not catching exceptions from `forwardKinematics()`.

## Judgment calls (flagging per standing policy, not blocking on them)
- **clang-format base style**: `Microsoft` base + `UseTab: Always`, `NamespaceIndentation: All`, `PointerAlignment/ReferenceAlignment: Left`, `SortIncludes: false` — tuned specifically to minimize the reformat diff against this codebase's existing Allman/tab/left-ref conventions.
- **Checks kept disabled in `.clang-tidy`** (each with an inline rationale comment): narrowing-conversions (04f solver fragility), magic-numbers/identifier-length/uppercase-literal-suffix/braces-around-statements (repo conventions, zero-benefit churn), use-trailing-return-type and avoid-c-arrays (unused style / public-API-breaking), function-cognitive-complexity and pro-bounds-constant-array-index (inherent to the geometric IK solver and DH-parameter array indexing), performance-enum-size (public API ABI change).
- **`inverseKinematics()` narrowing-conversion warning**: suppressed for the whole function via `#pragma warning(disable: 4244)` rather than edited, since task 04f already showed that even neutral-looking rewrites in this exact solver shift golden values via extra rounding near singularities.
- Only tested `/W4` on MSVC locally (no full clang/gcc toolchain available in this environment) — `-Wall -Wextra -Wpedantic` is a smaller warning set than `/W4`, so I expect it to pass on ubuntu/macos CI, but that's unverified until CI runs.

## Test plan
- [x] `clang-format --dry-run -Werror` clean over `include/ src/ apps/ tests/`
- [x] `cppcheck --enable=warning,performance,portability --error-exitcode=1 --inline-suppr` clean
- [x] `clang-tidy` clean (curated checks) on `src/*.cpp` + `apps/**/*.cpp`
- [x] Debug and Release presets build clean with warnings-as-errors (MSVC /W4 /WX)
- [x] `ctest` 22/22 passing on both presets; golden suite bit-identical (no functional changes)
- [ ] CI matrix (6-job build + lint job) green on all platforms — watching after push, per standing policy: not merging, waiting for CodeRabbit review first.

Closes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed uninitialized inverse-kinematics validity flags.
  * Corrected benchmark timing initialization and improved handling of invalid solutions.
  * Added clearer error handling for demo failures.

* **Build & Quality**
  * Added automatic C/C++ formatting and static-analysis checks.
  * Enforced compiler warnings for project targets without affecting third-party code.
  * Standardized code formatting across the project and tests.

* **Documentation**
  * Updated the unreleased changelog with bug fixes and quality improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->