### PR TITLE
docs: convert XML-style doc comments to Doxygen (#24, 1/N)

### DIFF
--- a/include/ur_kinematics/robot_parameters.h
+++ b/include/ur_kinematics/robot_parameters.h
@@ -7,9 +7,7 @@
 namespace universalRobots
 {
 
-	/// <summary> URtype
-	/// Different types of URs.
-	/// </summary>
+	/** @brief Different types of URs. */
 	enum URtype : unsigned int
 	{
 		UR3,
@@ -17,10 +15,11 @@ namespace universalRobots
 		UR10 // 0, 1, 2
 	};
 
-	/// <summary>
-	/// Denavit-Hartenberg link dimensions (meters) for a UR model.
-	/// d - z-axis translations (d[6] is the end-effector slot); a - x-axis translations.
-	/// </summary>
+	/**
+	 * @brief Denavit-Hartenberg link dimensions (meters) for a UR model.
+	 *
+	 * d - z-axis translations (d[6] is the end-effector slot); a - x-axis translations.
+	 */
 	struct RobotParameters
 	{
 		URtype type;
@@ -38,9 +37,7 @@ namespace universalRobots
 										   .d = {0.109f, 0.10122f, 0.01945f, -0.00661f, 0.0584f, 0.09372f, 0.0f},
 										   .a = {0.6121f, 0.5722f, 0.0573f, 0.0584f}};
 
-	/// <summary>
-	/// Returns the DH parameters for a given UR model. Unknown values fall back to UR10.
-	/// </summary>
+	/** @brief Returns the DH parameters for a given UR model. Unknown values fall back to UR10. */
 	constexpr const RobotParameters& parametersFor(const URtype type)
 	{
 		switch (type)

--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -12,19 +12,13 @@
 namespace universalRobots
 {
 
-	/// <summary>
-	/// Converts an angle in degrees to radians.
-	/// </summary>
+	/** @brief Converts an angle in degrees to radians. */
 	float rad(float degree);
 
-	/// <summary>
-	/// Converts an angle in radians to degrees.
-	/// </summary>
+	/** @brief Converts an angle in radians to degrees. */
 	float deg(float rad);
 
-	/// <summary>
-	/// Structure which holds a pose { x y z } { alpha beta gamma }
-	/// </summary>
+	/** @brief Structure which holds a pose { x y z } { alpha beta gamma } */
 	struct pose
 	{
 		float m_pos[3] = {};		 // x y z (meters)
@@ -82,58 +76,44 @@ namespace universalRobots
 		}
 	};
 
-	/// <summary>
-	/// Structure which holds the current value and pose of a joint.
-	/// </summary>
+	/** @brief Structure which holds the current value and pose of a joint. */
 	struct joint
 	{
 		pose m_jointPose;
 		float m_jointValue = 0.0f;
 	};
 
-	/// <summary>
-	/// Implements 'UR robot type' object.
-	/// </summary>
+	/** @brief Implements 'UR robot type' object. */
 	class UR
 	{
 	  public:
-		/// <summary>
-		/// Number of Degrees of Freedom is always 6 for all URs.
-		/// </summary>
+		/** @brief Number of Degrees of Freedom is always 6 for all URs. */
 		static constexpr unsigned int m_numDoF = 6;
 
-		/// <summary>
-		/// Number of translations in the z-axis is always 7 (this includes a translation for the end-effector).
-		/// </summary>
+		/** @brief Number of translations in the z-axis is always 7 (this includes a translation for the end-effector).
+		 */
 		static constexpr unsigned int m_numTransZ = 7;
 
-		/// <summary>
-		/// Number of translations in the x-axis is always 4.
-		/// </summary>
+		/** @brief Number of translations in the x-axis is always 4. */
 		static constexpr unsigned int m_numTransX = 4;
 
-		/// <summary>
-		/// Number of frames is pre-defined (according to the MDH convention it is 9).
-		/// </summary>
+		/** @brief Number of frames is pre-defined (according to the MDH convention it is 9). */
 		static constexpr unsigned int m_numReferenceFrames = 9;
 
-		/// <summary>
-		/// Number of inverse kinematics solutions for a UR is 8.
-		/// </summary>
+		/** @brief Number of inverse kinematics solutions for a UR is 8. */
 		static constexpr unsigned int m_numIkSol = 8;
 
-		/// <summary>
-		/// Six joint angles (radians), in joint order 1..6.
-		/// </summary>
+		/** @brief Six joint angles (radians), in joint order 1..6. */
 		using JointVector = std::array<float, m_numDoF>;
 
-		/// <summary>
-		/// The eight inverse-kinematics solutions, each a full joint vector.
-		/// valid[i] is true when solution i is geometrically feasible (no NaN angles).
-		/// anyValid() returns true when at least one solution exists.
-		/// For invalid rows, angle values are NaN — old-style consumers checking
-		/// std::isnan() continue to work; valid[] is the authoritative flag.
-		/// </summary>
+		/**
+		 * @brief The eight inverse-kinematics solutions, each a full joint vector.
+		 *
+		 * valid[i] is true when solution i is geometrically feasible (no NaN angles).
+		 * anyValid() returns true when at least one solution exists.
+		 * For invalid rows, angle values are NaN — old-style consumers checking
+		 * std::isnan() continue to work; valid[] is the authoritative flag.
+		 */
 		struct IkSolutions
 		{
 			std::array<std::array<float, m_numDoF>, m_numIkSol> solutions = {};
@@ -146,55 +126,51 @@ namespace universalRobots
 		};
 
 	  private:
-		/// <summary>
-		/// Robot type/name UR 3, 5, or 10.
-		/// </summary>
-		/// <returns>0, 1, 2</returns>
+		/** @brief Robot type/name UR 3, 5, or 10. Values: 0, 1, 2. */
 		URtype m_type = UR10;
 
-		/// <summary>
-		/// d - translation (meters) in the z-axis (the last translation d[6] is for an end-effector).
-		/// d_i is a nomeclature convention.
-		/// </summary>
+		/**
+		 * @brief d - translation (meters) in the z-axis (the last translation d[6] is for an end-effector).
+		 *
+		 * d_i is a nomeclature convention.
+		 */
 		std::array<float, m_numTransZ> m_d = kUR10.d;
 
-		/// <summary>
-		/// a - translation (meters) in the x-axis.
-		/// a_i is a nomeclature convention.
-		/// </summary>
+		/**
+		 * @brief a - translation (meters) in the x-axis.
+		 *
+		 * a_i is a nomeclature convention.
+		 */
 		std::array<float, m_numTransX> m_a = kUR10.a;
 
-		/// <summary>
-		/// Position, Euler Angles, and Value of the robot's joints. {x, y, z} {alpha, beta, gamma} {jointValue}
-		/// </summary>
+		/** @brief Position, Euler Angles, and Value of the robot's joints. {x, y, z} {alpha, beta, gamma} {jointValue}
+		 */
 		joint m_jointState[m_numDoF] = {};
 
 		// Create an array of (individual) transformation matrices iTi+1 / i-1Ti
 
-		/// <summary>
-		/// Array of (individual) transformation matrices iTi+1 / i-1Ti
-		/// </summary>
+		/** @brief Array of (individual) transformation matrices iTi+1 / i-1Ti */
 		Eigen::Matrix4f m_individualTransformationMatrices[m_numReferenceFrames] = {};
 
-		/// <summary>
-		/// Array of (general) transformation matrices 0Ti
-		/// </summary>
+		/** @brief Array of (general) transformation matrices 0Ti */
 		Eigen::Matrix4f m_generalTransformationMatrices[m_numReferenceFrames] = {};
 
-		/// <summary>
-		/// This boolean indicates whether a tool is/isnt attached to the robot.
-		/// Must be specified in the constructor, if not default is false.
-		/// Currently stored but not read anywhere (endEffectorDimension alone drives
-		/// forwardKinematics); kept for API/ABI stability rather than removed, since
-		/// that's a behavior question out of scope for a lint-only change.
-		/// </summary>
+		/**
+		 * @brief This boolean indicates whether a tool is/isnt attached to the robot.
+		 *
+		 * Must be specified in the constructor, if not default is false.
+		 * Currently stored but not read anywhere (endEffectorDimension alone drives
+		 * forwardKinematics); kept for API/ABI stability rather than removed, since
+		 * that's a behavior question out of scope for a lint-only change.
+		 */
 		[[maybe_unused]] bool m_endEffector = false;
 
-		/// <summary>
-		/// Modified Denavit-Hartenberg parameters matrix (9x4)
-		/// { alpha_i-1, a_i-1, d_i, theta_i } for each frame.
-		/// Populated by setMDHmatrix() from the constructor.
-		/// </summary>
+		/**
+		 * @brief Modified Denavit-Hartenberg parameters matrix (9x4)
+		 * { alpha_i-1, a_i-1, d_i, theta_i } for each frame.
+		 *
+		 * Populated by setMDHmatrix() from the constructor.
+		 */
 		Eigen::Matrix<float, m_numReferenceFrames, 4> m_MDHmatrix;
 
 	  public:


### PR DESCRIPTION
## Summary
First PR of task 07 (docs + v2.0.0 release). Converts the XML-style `/// <summary>...</summary>` doc comments in the two public headers (`include/ur_kinematics/ur_kinematics.h`, `include/ur_kinematics/robot_parameters.h`) to standard Doxygen `/** @brief ... */` style, per #24.

- Comment-style-only change, zero behavior change.
- Golden characterization suite + full unit/property suite: 50/50 passing, bit-identical.
- Verified zero Doxygen warnings on both converted headers locally (doxygen 1.16.1, against the repo's `Doxyfile.in` `INPUT` set).
- clang-format clean.

Plain `///` comments without XML `<summary>` wrapping (already valid Doxygen as-is) were left untouched, matching the narrower scope in the task 07 spec.

Note for a follow-up PR: doxygen also emits an unrelated pre-existing warning ("unable to resolve reference to docs/REFERENCES.md for \ref command") from README.md's existing markdown link — not touched here since it's outside this PR's comment-conversion scope; will address alongside the README PR (#2 in the task 07 sequence).

## Test plan
- [x] `cmake --build --preset release`
- [x] `ctest --test-dir build/release -C Release` — 50/50 passing
- [x] `doxygen` against `Doxyfile.in`-derived config — zero warnings on `include/ur_kinematics/*.h`
- [x] `clang-format --dry-run -Werror` on both changed files
- [ ] CI (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Doxygen formatting and consistency across robot parameter and kinematics API documentation.
  * Clarified descriptions for angle conversion helpers, robot types, joint data, inverse kinematics information, and internal kinematics state.
  * No functional behavior, public interfaces, constants, or data structures were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->