### PR TITLE
docs: tighten README against new typed IK API (#20, 2/N)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This repository is the **C++ library** (UR3/UR5/UR10, C++20, CMake). The origina
 
 The C++ solution uses **C++20** and builds on **Windows, Linux, and macOS** via CMake.
 
-### The `UR class`
+### The `UR` class
 
 Instantiate a robot and call `forwardKinematics` or `inverseKinematics`:
 
@@ -55,6 +55,9 @@ universalRobots::pose tip = robot.forwardKinematics(joints);
 
 // Inverse kinematics (up to 8 solutions)
 const universalRobots::UR::IkSolutions ikSols = robot.inverseKinematics(tip);
+
+// ikSols.valid[i] tells you whether ikSols.solutions[i] is a real solution
+const bool hasSolution = ikSols.anyValid();
 ```
 
 Supported robot types: `URtype::UR3`, `URtype::UR5`, `URtype::UR10`.


### PR DESCRIPTION
## Summary
- Fix `` `UR class` `` code-span typo -> `` `UR` `` class
- Show `ikSols.anyValid()` / `valid[]` usage in the FK+IK example — this API (typed `IkSolutions` with per-solution validity flags) was added in task 04e / #38 and post-dates the README's last update, so the example previously left readers to guess how to interpret solutions.

Recon confirmed the rest of the README (badges, build/test instructions, dependency versions, CMake preset requirements, image references) is already accurate against the post-refactor API — this is a tightening pass, not a rewrite, per the task-07 plan.

## Verification
- Compiled the FK+IK snippet standalone (verbatim, as it appears in the README) against `include/` with `cl /std:c++20 /W4` — zero errors/warnings, both before and after the `anyValid()` addition.
- No source/golden-test files touched; doc-only change.

## Test plan
- [x] Snippet compiles standalone against current headers
- [x] No changes to src/include/tests (doc-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `UR` class documentation heading.
  * Expanded the inverse kinematics example to show how to check whether solutions are available and identify valid solutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->