### PR TITLE
docs: add GitHub Wiki pages (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <a href="https://codecov.io/gh/Jgocunha/universal-robots-kinematics"><img src="https://img.shields.io/codecov/c/github/Jgocunha/universal-robots-kinematics?style=flat-square&logo=codecov&logoColor=white" alt="Coverage" /></a>
   <a href="https://github.com/Jgocunha/universal-robots-kinematics/releases/latest"><img src="https://img.shields.io/github/v/release/Jgocunha/universal-robots-kinematics?style=flat-square&logo=github&logoColor=white" alt="Latest Release" /></a>
   <a href="https://jgocunha.github.io/universal-robots-kinematics/"><img src="https://img.shields.io/badge/docs-doxygen-blue?style=flat-square&logo=readthedocs&logoColor=white" alt="Docs" /></a>
+  <a href="https://github.com/Jgocunha/universal-robots-kinematics/wiki"><img src="https://img.shields.io/badge/docs-wiki-blue?style=flat-square&logo=githubpages&logoColor=white" alt="Wiki" /></a>
 </p>
 
 <p align="center">

--- a/docs/wiki/Benchmarking.md
+++ b/docs/wiki/Benchmarking.md
@@ -1,0 +1,42 @@
+# Benchmarking
+
+Benchmarking consists of two parts:
+
+1. measuring the [compute time](https://stackoverflow.com/questions/22387586/measuring-execution-time-of-a-function-in-c) of the forward and inverse kinematics functions;
+2. measuring the round-trip error of the solutions (FK ∘ IK).
+
+The published results were produced over a set of 100,000 randomly generated target tip poses (generated via `UR::generateRandomReachablePose()`), run on a Ryzen 5 3600 CPU at 4.28 GHz. The harness lives in `apps/demo/benchmarking.cpp` and is run from `ur_demo`.
+
+## Average computation times
+
+|  | MATLAB | C++ |
+|---|---|---|
+| Forward Kinematics | 1.832571E-05 s | 1.39434E-06 s |
+| Inverse Kinematics | 1.612797E-04 s | 1.07403E-05 s |
+
+MATLAB's compute times are roughly 10× slower than the C++ solution.
+
+## Average error
+
+Error is computed by round-tripping a random reachable pose through inverse kinematics and back through forward kinematics, then comparing against the original:
+
+![How to get the errors](https://raw.githubusercontent.com/Jgocunha/universal-robots-kinematics/main/docs/images/error-calculation.png)
+
+|  | *x* | *y* | *z* | *alpha* | *beta* | *gamma* |
+|---|---|---|---|---|---|---|
+| average error | 7.45E-14 | 1.86E-14 | 7.45E-14 | 4.14E-06 | 4.14E-06 | 4.14E-06 |
+
+**Units**: *x, y, z* in metres; *alpha, beta, gamma* in radians.
+
+## Reproducing the results
+
+Build and run the demo (see [Getting Started](Getting-Started)):
+
+```bash
+cmake --preset release
+cmake --build --preset release
+./build/release/ur_demo          # Linux/macOS
+build\release\Release\ur_demo.exe # Windows
+```
+
+The demo runs the benchmarking harness and prints timing and error statistics to the console.

--- a/docs/wiki/CoppeliaSim-Integration.md
+++ b/docs/wiki/CoppeliaSim-Integration.md
@@ -1,0 +1,20 @@
+# CoppeliaSim Integration
+
+This repository (`universal-robots-kinematics`) is the **C++ kinematics library only**. As of the v2.0.0 restructuring, CoppeliaSim integration is no longer part of this repo — it was removed along with the MATLAB reference implementation.
+
+## Where it moved
+
+The original MATLAB kinematics implementation, the CoppeliaSim scenes/models for UR3/UR5/UR10, and the CoppeliaSim C++ remote-API integration all now live in the archive repository:
+
+**[Jgocunha/universal-robots-kinematics-matlab](https://github.com/Jgocunha/universal-robots-kinematics-matlab)**
+
+That repository includes the CoppeliaSim launch instructions (previously `LAUNCH.md` here) and the scene files for all three UR models.
+
+## Using this library alongside a simulator
+
+If you want to drive a CoppeliaSim (or any other) simulation using this C++ library, the intended pattern is:
+
+1. Use `UR::forwardKinematics()` / `UR::inverseKinematics()` from this library to compute joint values or tip poses.
+2. Send those joint values to your simulator through whatever integration layer it exposes (e.g. CoppeliaSim's remote API, ROS, etc.) — that glue code is outside the scope of this library.
+
+This library has no simulator dependency and no CoppeliaSim-specific code; it only performs the kinematics math.

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,73 @@
+# Getting Started
+
+## Requirements
+
+- CMake 3.21+ (for presets; the build itself needs 3.20+)
+- A C++20 compiler: GCC 10+, Clang 12+, or MSVC 19.29+
+- Git — [Eigen](#dependencies) and [GoogleTest](#dependencies) are fetched from GitHub at configure time, so no manual installation is needed for either.
+
+Supported platforms: Windows, Linux, macOS.
+
+## Dependencies
+
+Both dependencies are fetched automatically by CMake's `FetchContent` at configure time:
+
+- **[Eigen 3.4.0](https://eigen.tuxfamily.org/)** — linear algebra (matrices/vectors) used throughout the kinematics solver.
+- **[GoogleTest v1.15.2](https://github.com/google/googletest)** — used to build the test suite only.
+
+## Building
+
+The build uses CMake presets (`debug`, `release`) with the default generator on each platform.
+
+```bash
+# Clone
+git clone https://github.com/Jgocunha/universal-robots-kinematics.git
+cd universal-robots-kinematics
+
+# Configure and build (Eigen and GoogleTest are downloaded automatically)
+cmake --preset release
+cmake --build --preset release
+
+# Run the demo
+./build/release/ur_demo          # Linux/macOS
+build\release\Release\ur_demo.exe # Windows
+```
+
+Swap `release` for `debug` to build the debug configuration under `build/debug`.
+
+## Running the tests
+
+```bash
+ctest --test-dir build/release --output-on-failure   # add -C Release on Windows/multi-config
+```
+
+### Coverage (GCC/Clang only)
+
+```bash
+cmake -B build/coverage -DCMAKE_BUILD_TYPE=Debug -DUR_KINEMATICS_COVERAGE=ON
+cmake --build build/coverage
+ctest --test-dir build/coverage --output-on-failure
+gcovr --root . --filter 'include/.*' --filter 'src/.*' --object-directory build/coverage
+```
+
+## Using the library in your own project
+
+Instantiate a robot and call `forwardKinematics` or `inverseKinematics`:
+
+```cpp
+#include <ur_kinematics/ur_kinematics.h>
+
+universalRobots::UR robot(universalRobots::URtype::UR5);
+
+// Forward kinematics
+const universalRobots::UR::JointVector joints = { 0.4f, -1.0f, 1.2f, 0.3f, 0.8f, 0.2f }; // radians
+universalRobots::pose tip = robot.forwardKinematics(joints);
+
+// Inverse kinematics (up to 8 solutions)
+const universalRobots::UR::IkSolutions ikSols = robot.inverseKinematics(tip);
+
+// ikSols.valid[i] tells you whether ikSols.solutions[i] is a real solution
+const bool hasSolution = ikSols.anyValid();
+```
+
+See the [UR Class API](UR-Class-API) page for the full public interface.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,14 @@
+# universal-robots-kinematics Wiki
+
+A C++20 library for forward and inverse kinematics of Universal Robots (UR3/UR5/UR10) manipulators, based on the Modified Denavit-Hartenberg (MDH) convention.
+
+## Pages
+
+- **[Getting Started](Getting-Started)** — dependencies and build instructions.
+- **[UR Class API](UR-Class-API)** — constructor, `forwardKinematics()`, `inverseKinematics()`, and the other public members.
+- **[Modified Denavit-Hartenberg Convention](Modified-Denavit-Hartenberg-Convention)** — the 9-frame MDH parameterisation this library uses.
+- **[Kinematics Theory](Kinematics-Theory)** — how forward and inverse kinematics are derived and solved.
+- **[Benchmarking](Benchmarking)** — how to reproduce the timing and accuracy results.
+- **[CoppeliaSim Integration](CoppeliaSim-Integration)** — where the CoppeliaSim scenes and remote-API integration now live.
+
+For citations to the papers and textbook behind the kinematics analysis, see [`docs/REFERENCES.md`](https://github.com/Jgocunha/universal-robots-kinematics/blob/main/docs/REFERENCES.md) in the repository.

--- a/docs/wiki/Kinematics-Theory.md
+++ b/docs/wiki/Kinematics-Theory.md
@@ -1,0 +1,42 @@
+# Kinematics Theory
+
+This page summarises how `forwardKinematics()` and `inverseKinematics()` work. For the full derivation with figures, see the project dissertations cited in [`docs/REFERENCES.md`](https://github.com/Jgocunha/universal-robots-kinematics/blob/main/docs/REFERENCES.md).
+
+## Forward kinematics
+
+Given the 6 joint angles, forward kinematics is a straightforward chain of the 9 [MDH](Modified-Denavit-Hartenberg-Convention) transforms:
+
+1. Build the 9×4 MDH parameter matrix for the current joint values (`setMDHmatrix()`).
+2. Convert each row into an individual homogeneous transform `_{i-1}T_i` (`calcTransformationMatrix()`).
+3. Chain them left-to-right into general transforms `_0T_i = _0T_1 \cdot _1T_2 \cdots _{i-1}T_i`.
+4. `_0T_7` (frame 8) gives the tip's position and orientation directly; the position is the last column, and the orientation (Euler angles, ZYX) is extracted from the rotation block via `Eigen::Matrix3f::eulerAngles`.
+
+Along the way, the general transforms for the pose-bearing frames (0, 1, 2, 3, 5, 7 — corresponding to joints 1–6) are also captured as each joint's own pose, which is why `operator<<` can print every joint's position/orientation, not just the tip's.
+
+## Inverse kinematics
+
+Given a target tip pose, the solver is **geometric** (closed-form), not iterative — it exploits the fact that the last three joint axes intersect at the wrist centre to decouple position from orientation, following the well-known Pieper approach for spherical-wrist manipulators (see refs. 3–5, 9 in `docs/REFERENCES.md`). It returns **up to 8 solutions**, corresponding to every combination of:
+
+- **Shoulder left / right** (`theta1`) — two solutions for the base rotation that place the wrist centre at the required horizontal distance from the base axis.
+- **Elbow up / down** (`theta3`, and consequently `theta2`, `theta4`) — two solutions for the elbow bend that reach a given wrist-centre position.
+- **Wrist up / down** (`theta5`, and consequently `theta6`) — two solutions for the wrist orientation that reach the required tip orientation.
+
+2 × 2 × 2 = 8 solutions total, indexed 0–7. `IkSolutions::valid[i]` tells you which of the 8 are geometrically feasible for the given target pose (a target outside the workspace, or requiring an unreachable combination, invalidates the corresponding rows).
+
+### Where solutions can fail: `acos` domain checks
+
+The solver computes several joint angles via `acos()` of a ratio derived from the target pose and the robot's link dimensions. Three sites in `inverseKinematics()` check whether that ratio falls in `[-1, 1]` (with a small epsilon for floating-point slack):
+
+1. `theta1` (shoulder) — if out of domain, **all 8** solutions are invalid (the target is outside the reachable radius from the base).
+2. `theta5` (wrist) — if out of domain for solution `i`, only that solution is invalid.
+3. `theta3` (elbow) — if out of domain for solution `i`, only that solution is invalid.
+
+### Wrist singularity
+
+When `theta5` is 0 or ±π, the joint-6 rotation axis becomes (anti-)parallel to the joint-4 axis, and `theta6` becomes underdetermined (the usual formula divides by `sin(theta5) == 0`). By convention, this library pins `theta6 = 0` at that singularity and solves the remaining joints consistently for that choice — the wrist centre and orientation are still correct, just with one particular (arbitrary but repeatable) split between joints 4 and 6.
+
+### Getting a NaN-free solution
+
+Use `IkSolutions::anyValid()` (or `UR::isPoseReachable()`) to check reachability, then pick a valid row with `IkSolutions::valid[i]` (or `UR::isSolutionValid(solutions[i])` on an individual row).
+
+See the [UR Class API](UR-Class-API) page for the exact function signatures.

--- a/docs/wiki/Modified-Denavit-Hartenberg-Convention.md
+++ b/docs/wiki/Modified-Denavit-Hartenberg-Convention.md
@@ -1,0 +1,38 @@
+# Modified Denavit-Hartenberg Convention
+
+This library parameterises each UR robot using the **Modified Denavit-Hartenberg (MDH)** convention (as opposed to the "standard"/Classic DH convention). Each link transform is built from 4 parameters `{alpha_{i-1}, a_{i-1}, d_i, theta_i}`:
+
+- `alpha_{i-1}` — twist angle between z_{i-1} and z_i, measured about x_{i-1}.
+- `a_{i-1}` — link length, the distance between z_{i-1} and z_i measured along x_{i-1}.
+- `d_i` — link offset, the distance between x_{i-1} and x_i measured along z_i.
+- `theta_i` — joint angle, the angle between x_{i-1} and x_i measured about z_i.
+
+This is the convention used in Craig's / Jazar's robotics textbooks, and matches the UR manufacturer parameters referenced in [`docs/REFERENCES.md`](https://github.com/Jgocunha/universal-robots-kinematics/blob/main/docs/REFERENCES.md).
+
+## Why 9 frames for a 6-DoF robot
+
+A UR arm has 6 revolute joints, but the last three axes (wrist) intersect at a single point and aren't mutually orthogonal in a way that a single-frame-per-joint MDH chain can express cleanly. This library splits the wrist into two extra half-frames, giving **9 reference frames** for 6 joints:
+
+| Frame | From → To | Joint |
+|---|---|---|
+| 0 | `0T1` | Joint 1 |
+| 1 | `1T2` | Joint 2 |
+| 2 | `2T3` | Joint 3 |
+| 3 | `3T4` | Joint 4 |
+| 4 | `4T4'` | — (intermediate, fixed) |
+| 5 | `4'T5` | Joint 5 |
+| 6 | `5T5'` | — (intermediate, fixed) |
+| 7 | `5'T6` | Joint 6 |
+| 8 | `6T7` | — (tip / end-effector offset) |
+
+Frames 4 and 6 (`4T4'` and `5T5'`) carry no joint angle of their own — they're fixed `alpha`/`a` rotations that re-orient the frame so the next joint's rotation axis lines up correctly. This is what lets `theta5` and `theta6` be solved independently once the wrist position is known (see [Kinematics Theory](Kinematics-Theory)).
+
+Frame 8 (`6T7`) applies the end-effector offset (`d[6]`, set from the constructor's `endEffectorDimension` argument) and carries no joint.
+
+## Link dimensions
+
+Each robot's `{d_i}` (z-axis translations, 7 values) and `{a_i}` (x-axis translations, 4 values) live in `RobotParameters` (`include/ur_kinematics/robot_parameters.h`), one constant per model (`kUR3`, `kUR5`, `kUR10`). These are the measured hardware link dimensions for each UR variant; see `docs/REFERENCES.md` for the manufacturer documentation these were cross-checked against.
+
+## Where this is built
+
+`UR::setMDHmatrix()` (in `src/ur_kinematics.cpp`) assembles the 9×4 MDH matrix from the current joint values and the robot's `d`/`a` arrays every time joint values change. `forwardKinematics()` then converts each row into an individual transformation matrix (`calcTransformationMatrix()` in `src/math_utils.cpp`) and chains them to get the general (base-to-frame-i) transforms.

--- a/docs/wiki/UR-Class-API.md
+++ b/docs/wiki/UR-Class-API.md
@@ -1,0 +1,102 @@
+# UR Class API
+
+Everything lives in the `universalRobots` namespace (`#include <ur_kinematics/ur_kinematics.h>`).
+
+For the full generated API reference (all types, all members), see the [Doxygen docs](https://jgocunha.github.io/universal-robots-kinematics/). This page is a hand-written summary of the parts you'll actually use.
+
+## `URtype`
+
+```cpp
+enum URtype : unsigned int { UR3, UR5, UR10 };
+```
+
+Selects which robot's Denavit-Hartenberg link dimensions (`RobotParameters`, in `robot_parameters.h`) the `UR` object uses.
+
+## Constructing a robot
+
+```cpp
+UR(URtype robotType = UR10, bool endEffector = false, float endEffectorDimension = 0.0f);
+```
+
+- `robotType` — `UR3`, `UR5`, or `UR10`.
+- `endEffector` / `endEffectorDimension` — if your robot carries a tool, `endEffectorDimension` (metres) is added as a translation past the last joint before computing the tip pose.
+
+```cpp
+universalRobots::UR robot(universalRobots::URtype::UR5);
+universalRobots::UR robotWithTool(universalRobots::URtype::UR10, true, 0.15f); // tool 0.15 m past the flange
+```
+
+## `JointVector` and `IkSolutions`
+
+```cpp
+using JointVector = std::array<float, 6>; // radians, joint order 1..6
+
+struct IkSolutions
+{
+    std::array<std::array<float, 6>, 8> solutions;
+    std::array<bool, 8> valid;   // valid[i]: whether solutions[i] is geometrically feasible
+    bool anyValid() const;       // true if at least one solution is valid
+};
+```
+
+Invalid rows are filled with NaN angles rather than omitted, so `solutions` always has exactly 8 entries; check `valid[i]` (or call `isSolutionValid(solutions[i])`) before using a given row.
+
+## `forwardKinematics`
+
+```cpp
+[[nodiscard]] pose forwardKinematics(const JointVector& targetJointVal);
+```
+
+Computes the tip `pose` for a given set of 6 joint angles (radians). Throws `std::invalid_argument` if any joint value is non-finite or outside `[-2π, 2π]`.
+
+## `inverseKinematics`
+
+```cpp
+[[nodiscard]] IkSolutions inverseKinematics(const pose& targetTipPose);
+```
+
+Computes all 8 geometric inverse-kinematics solutions for a target tip pose (position + Euler angles). See [Kinematics Theory](Kinematics-Theory) for how the 8 solutions correspond to shoulder-left/right, elbow-up/down, and wrist-up/down configurations.
+
+## `isPoseReachable`
+
+```cpp
+[[nodiscard]] bool isPoseReachable(const pose& targetPose);
+```
+
+Equivalent to `inverseKinematics(targetPose).anyValid()` — use this when you only need a yes/no reachability answer.
+
+## `generateRandomReachablePose`
+
+```cpp
+pose generateRandomReachablePose();
+```
+
+Picks random joint angles within the robots' limits and runs forward kinematics, returning a pose that is reachable by construction. Useful for tests and benchmarking (see [Benchmarking](Benchmarking)).
+
+## `isSolutionValid` (static)
+
+```cpp
+[[nodiscard]] static bool isSolutionValid(const std::array<float, 6>& ikSolution);
+```
+
+Returns `true` if none of the 6 joint values in `ikSolution` are NaN. This is what `IkSolutions::valid[i]` is derived from.
+
+## `pose`
+
+```cpp
+struct pose
+{
+    float m_pos[3];         // x, y, z (metres)
+    float m_eulerAngles[3]; // alpha, beta, gamma (radians, ZYX convention)
+};
+```
+
+Constructible from position + Euler angles, or from position + an `Eigen::Matrix3f` rotation matrix. Supports `operator-` and `operator/` for computing pose errors (see [Benchmarking](Benchmarking)).
+
+## Printing a robot
+
+Both `URtype` and `UR` have `operator<<` overloads for `std::ostream`, printing the robot's DH parameters, current joint values/poses, and all intermediate transformation matrices — useful for debugging.
+
+```cpp
+std::cout << robot;
+```


### PR DESCRIPTION
## Summary
- Adds 6 Wiki pages under `docs/wiki/` for review here first (Home, Getting Started, UR Class API, Modified Denavit-Hartenberg Convention, Kinematics Theory, Benchmarking, CoppeliaSim Integration) — will be pushed to the repo's actual GitHub Wiki (`*.wiki.git`) once this merges.
- Content reflects the **current** (post-v2.0.0-restructuring) repo scope: CMake presets build (no Visual Studio), current typed API (`JointVector`, `IkSolutions`, `isSolutionValid`), and points CoppeliaSim/MATLAB content at the archive repo (`Jgocunha/universal-robots-kinematics-matlab`) rather than duplicating removed content, since issue #28's original page list (written before the C++/MATLAB split) referenced things like `LAUNCH.md` and Visual Studio build steps that no longer apply to this repo.
- README gets a `docs-wiki` badge next to the existing `docs-doxygen` badge, linking to the Wiki (per #28's ask to surface the Wiki link once pages exist — the originally-referenced commented-out link no longer exists post-README-rewrite, so this adds a visible link instead).

Closes #28 once merged and mirrored to the Wiki.

## Test plan
- [x] Content cross-checked against current `include/ur_kinematics/*.h` and `src/ur_kinematics.cpp` for API/behavior accuracy (constructor, FK/IK signatures, 8-solution structure, acos domain checks, wrist singularity handling, 9-frame MDH layout).
- [x] Benchmarking figures/table copied verbatim from README (single source of truth, no drift).
- [ ] CodeRabbit review (pending).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a GitHub Wiki badge link to the README for easier access to project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->