### PR TITLE
fix: exclude FetchContent'd Eigen3/GoogleTest from install (release archive leak)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,13 @@ set(EIGEN_BUILD_DOC OFF CACHE BOOL "" FORCE)
 set(BUILD_TESTING   OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(Eigen3)
 
+# Eigen has no install-toggle option of its own; exclude its subdirectory from the
+# default build/install so `cmake --install` doesn't ship its headers and CMake
+# package config alongside our own release archives. Eigen3::Eigen is header-only
+# (INTERFACE), so this only suppresses Eigen's own all-target/install() rules -- it
+# does not affect our usage of it (re-added as SYSTEM include dirs below).
+set_property(DIRECTORY ${eigen3_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL TRUE)
+
 # Eigen's own headers trip our -Wall/-Wextra/-Wpedantic /-W4 (its CMakeLists
 # doesn't mark its include dirs SYSTEM). Re-add them as SYSTEM on our targets
 # so warnings-as-errors only applies to our own code, not template

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,9 @@ FetchContent_Declare(
 )
 # On Windows/MSVC, link GoogleTest against the shared CRT to match the default.
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# We only need GoogleTest to build the test suite, not ship it in release archives
+# (cmake --install would otherwise pull in its headers/libs/CMake package config).
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 include(GoogleTest)


### PR DESCRIPTION
## Summary
Found during the v2.0.0-rc.1 dry-run (#26): `cmake --install` (the exact command `release.yml` uses) swept up Eigen3's and GoogleTest's own `install()` rules alongside our own, so every release archive shipped their full headers/libs/CMake package configs on top of the intended deliverable — e.g. the Windows archive had 689 files (~31MB), including `gtest.lib`/`gmock.lib`/`gmock_main.lib` (~13MB) and Eigen's complete header tree + CMake package config, when only ~15 files were expected.

- `tests/CMakeLists.txt`: `set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)` before `FetchContent_MakeAvailable(googletest)` — GoogleTest's own purpose-built flag for this.
- `CMakeLists.txt`: `set_property(DIRECTORY ${eigen3_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL TRUE)` after `FetchContent_MakeAvailable(Eigen3)` — Eigen has no equivalent flag, so this excludes its subdirectory from the default build/install instead. Eigen3::Eigen is header-only (INTERFACE) and already re-added as a SYSTEM include on our own targets, so this only suppresses Eigen's own all-target/install() rules, not our usage of it.

No API/behavior change; golden suite unaffected.

## Test plan
- [x] `cmake --install build --config Release` to a throwaway prefix — install tree is exactly the intended 6 entries: `LICENSE`, `README.md`, `bin/ur_demo.exe`, `include/ur_kinematics/{robot_parameters.h,ur_kinematics.h}`, `lib/ur_kinematics.lib`. Zero gtest/gmock/Eigen files.
- [x] `ur_kinematics` + `ur_demo` build and link; test suite (`ur_kinematics_tests`) still builds and links against GoogleTest (only its *install* is skipped, not its build).
- [x] `ctest` — 50/50 tests pass (golden suite bit-identical).
- [ ] CodeRabbit review (pending).