### PR TITLE
fix: resolve Doxygen build warnings (#24 Pages-verify)

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -26,7 +26,6 @@ DOT_IMAGE_FORMAT       = svg
 UML_LOOK               = YES
 CALL_GRAPH             = YES
 CALLER_GRAPH           = YES
-CLASS_DIAGRAMS         = YES
 COLLABORATION_GRAPH    = YES
 
 WARN_IF_UNDOCUMENTED   = YES

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 This work was developed in the context of our MSc dissertations: *A Collaborative Work Cell to Improve Ergonomics and Productivity* by João Cunha, and *Human-Like Motion Generation through Waypoints for Collaborative Robots in Industry 4.0* by João Pereira, in which we got to work with the collaborative robotic arm **UR10 e-series**. 
 
-Before producing our kinematics solution, we conducted a comprehensive literature review on the UR robots’ kinematics (see [`docs/REFERENCES.md`](docs/REFERENCES.md)) and realised there was a lack of thorough and detailed analysis of their kinematics. Additionally, we found the [Universal Robots’ documentation](https://www.universal-robots.com/articles/ur/parameters-for-calculations-of-kinematics-and-dynamics/) confusing and unclear (at that time). 
+Before producing our kinematics solution, we conducted a comprehensive literature review on the UR robots’ kinematics (see [`docs/REFERENCES.md`](https://github.com/Jgocunha/universal-robots-kinematics/blob/main/docs/REFERENCES.md)) and realised there was a lack of thorough and detailed analysis of their kinematics. Additionally, we found the [Universal Robots’ documentation](https://www.universal-robots.com/articles/ur/parameters-for-calculations-of-kinematics-and-dynamics/) confusing and unclear (at that time). 
 
 Thus, the main goal of this work is to provide an **explicit and transparent guide into the UR robots kinematics** (using by reference the UR10 e-series) by expanding on the literature we found and describing every part of our analysis. 
 


### PR DESCRIPTION
## Summary
- Closes the last open item on #24 (Doxyfile/docs.yml/Pages-verify): the Doxyfile and docs.yml deploy workflow already exist and Pages is already live, but the last `Deploy Doxygen Docs` run (29212410650) emitted two real warnings that this PR fixes.
- `Doxyfile.in`: drop `CLASS_DIAGRAMS = YES` — obsolete tag per this Doxygen version, superseded by `UML_LOOK`.
- `README.md`: the `docs/REFERENCES.md` link used a relative path. Since `docs/` isn't part of the Doxyfile's `INPUT` (only `README.md include/`), Doxygen's markdown resolver tried and failed to `\ref` it, producing an "unable to resolve reference" warning on the generated main page. Pointed it at the GitHub blob URL instead (same pattern already used in `docs/wiki/*.md` for cross-repo links).

## Verification
Ran `doxygen` locally against the substituted Doxyfile (same substitution `docs.yml` does):
- Before: `CLASS_DIAGRAMS obsolete` + `unable to resolve reference to .../docs/REFERENCES.md` warnings present.
- After: both warnings gone. (Local run also shows `dot.exe` graph-rendering errors — Graphviz isn't installed on this dev machine; CI installs it via `apt-get install graphviz` and has been generating these graphs successfully in every prior `docs.yml` run, so that's not a regression.)

No functional/behavioral change to the library; docs-only.

## Test plan
- [x] Local `doxygen` build confirms both target warnings are resolved
- [ ] CI `docs.yml` run on merge to main deploys cleanly (workflow only triggers on push to `main`, so this can't run on the PR branch itself)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README with a direct link to the literature references.
* **Chores**
  * Removed class diagram generation from the documentation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->