### PR TITLE
docs: clarify generateRandomReachablePose() IK-recoverability gap

### DIFF
--- a/docs/wiki/UR-Class-API.md
+++ b/docs/wiki/UR-Class-API.md
@@ -73,6 +73,8 @@ pose generateRandomReachablePose();
 
 Picks random joint angles within the robots' limits and runs forward kinematics, returning a pose that is reachable by construction. Useful for tests and benchmarking (see [Benchmarking](Benchmarking)).
 
+Note that "reachable by construction" means the arm can physically get there — the pose is the forward-kinematics image of a real, in-limits joint configuration. It does **not** mean this library's analytic inverse-kinematics solver can necessarily recover a solution for it. A joint draw that swings the wrist center close to the base's vertical axis can land it inside a small cylindrical region around that axis that the solver's closed-form math cannot invert, so `isPoseReachable()` (and `inverseKinematics()`) may reject a fraction of the poses this function generates. In practice this affects roughly a fifth of draws across the full ±360° joint range (e.g. around 159/200 in a seeded UR3 run). If your use case needs every generated pose to be solvable, check `isPoseReachable()` on the result and redraw as needed.
+
 ## `isSolutionValid` (static)
 
 ```cpp


### PR DESCRIPTION
## Summary
- `generateRandomReachablePose()`'s doc previously said it returns a pose "reachable by construction," which is true but incomplete — it doesn't warn that the analytic IK solver can't invert every such pose.
- Clarifies the distinction: every returned pose is *physically* reachable (FK image of a real, in-limits joint vector), but a wide joint draw can place the wrist center inside a near-base-axis region this library's closed-form solver cannot invert, so `isPoseReachable()` may reject a fraction of generated poses (~1 in 5 across the full ±360° range, e.g. ~159/200 in a seeded UR3 run).
- Suggests checking `isPoseReachable()` on the result if callers need every draw to be solvable.

Doc-only change to `docs/wiki/UR-Class-API.md`. No code, golden, or behavior changes.

Closes #42.

## Non-goal (explicitly out of scope for this PR)
A retry/reject loop inside `generateRandomReachablePose()` that only returns IK-recoverable poses is a plausible follow-up, but it's a behavior change that deserves its own numerical review (this codebase has precedent for singularity/epsilon edge cases needing careful scrutiny — see the recent wrist-singularity fix in #52). Not bundled here.

## Test plan
- [x] Doc-only change; no build/test impact expected
- [x] Verified no other tracked file references the edited section in a way requiring updates
- [x] Confirmed via local build that `docs/wiki/UR-Class-API.md` renders as expected (plain markdown, no broken links/anchors introduced)