### PR TITLE
fix: accumulate benchmark average pose error over all samples

### DIFF
--- a/apps/demo/benchmarking.cpp
+++ b/apps/demo/benchmarking.cpp
@@ -13,7 +13,8 @@ namespace benchmark
 		universalRobots::UR::IkSolutions ikSols = {};
 		universalRobots::pose tipPoseOutput = {};
 		universalRobots::pose poseError = {};
-		universalRobots::pose sumAbsPoseError = {};
+		double sumAbsPos[3] = {0.0, 0.0, 0.0};
+		double sumAbsEuler[3] = {0.0, 0.0, 0.0};
 		universalRobots::pose avgPoseError = {};
 
 		std::chrono::duration<double, std::micro> invKin_us{};
@@ -52,14 +53,21 @@ namespace benchmark
 				poseError = tipPoseInput - tipPoseOutput;
 				for (unsigned int k = 0; k < 3; k++)
 				{
-					sumAbsPoseError.m_pos[k] += std::abs(poseError.m_pos[k]);
-					sumAbsPoseError.m_eulerAngles[k] += std::abs(poseError.m_eulerAngles[k]);
+					sumAbsPos[k] += std::abs(poseError.m_pos[k]);
+					sumAbsEuler[k] += std::abs(poseError.m_eulerAngles[k]);
 				}
 			}
 		}
 		avgInvKin_us = sumInvKin_us / ITERATIONS;
 		avgFwdKin_us = fkCalls > 0 ? sumFwdKin_us / fkCalls : std::chrono::duration<double, std::micro>::zero();
-		avgPoseError = fkCalls > 0 ? sumAbsPoseError / static_cast<float>(fkCalls) : universalRobots::pose{};
+		if (fkCalls > 0)
+		{
+			for (unsigned int k = 0; k < 3; k++)
+			{
+				avgPoseError.m_pos[k] = static_cast<float>(sumAbsPos[k] / fkCalls);
+				avgPoseError.m_eulerAngles[k] = static_cast<float>(sumAbsEuler[k] / fkCalls);
+			}
+		}
 
 		std::cout << "Generated " << ITERATIONS << " random valid tip poses for " << robot.getRobotType() << "..."
 				  << '\n';

--- a/apps/demo/benchmarking.cpp
+++ b/apps/demo/benchmarking.cpp
@@ -1,5 +1,6 @@
 // benchmarking.cpp
 
+#include <cmath>
 #include <iostream>
 #include "benchmarking.h"
 
@@ -12,6 +13,7 @@ namespace benchmark
 		universalRobots::UR::IkSolutions ikSols = {};
 		universalRobots::pose tipPoseOutput = {};
 		universalRobots::pose poseError = {};
+		universalRobots::pose sumAbsPoseError = {};
 		universalRobots::pose avgPoseError = {};
 
 		std::chrono::duration<double, std::micro> invKin_us{};
@@ -48,11 +50,16 @@ namespace benchmark
 				++fkCalls;
 				sumFwdKin_us = sumFwdKin_us + fwdKin_us;
 				poseError = tipPoseInput - tipPoseOutput;
+				for (unsigned int k = 0; k < 3; k++)
+				{
+					sumAbsPoseError.m_pos[k] += std::abs(poseError.m_pos[k]);
+					sumAbsPoseError.m_eulerAngles[k] += std::abs(poseError.m_eulerAngles[k]);
+				}
 			}
 		}
 		avgInvKin_us = sumInvKin_us / ITERATIONS;
 		avgFwdKin_us = fkCalls > 0 ? sumFwdKin_us / fkCalls : std::chrono::duration<double, std::micro>::zero();
-		avgPoseError = poseError / (ITERATIONS * universalRobots::UR::m_numIkSol);
+		avgPoseError = fkCalls > 0 ? sumAbsPoseError / static_cast<float>(fkCalls) : universalRobots::pose{};
 
 		std::cout << "Generated " << ITERATIONS << " random valid tip poses for " << robot.getRobotType() << "..."
 				  << '\n';
@@ -60,9 +67,10 @@ namespace benchmark
 		std::cout << "Average IK function execution time: " << avgInvKin_us.count() << "us" << '\n';
 		std::cout << "Each IK sol (" << fkCalls << ") has been run through forward kinematics..." << '\n';
 		std::cout << "Average FK function execution time: " << avgFwdKin_us.count() << "us" << '\n';
-		std::cout << "error = [tip_pose_input - tip_pose_output]" << '\n';
-		std::cout << "average error = " << avgPoseError.m_pos[0] << " " << avgPoseError.m_pos[1] << " "
-				  << avgPoseError.m_pos[2] << " " << avgPoseError.m_eulerAngles[0] << " "
+		std::cout << "error = mean |tip_pose_input - tip_pose_output| over all valid IK solutions" << '\n';
+		std::cout << "average position error (m): " << avgPoseError.m_pos[0] << " " << avgPoseError.m_pos[1] << " "
+				  << avgPoseError.m_pos[2] << '\n';
+		std::cout << "average orientation error (rad): " << avgPoseError.m_eulerAngles[0] << " "
 				  << avgPoseError.m_eulerAngles[1] << " " << avgPoseError.m_eulerAngles[2] << '\n';
 	}
 


### PR DESCRIPTION
## Summary
Fixes #55. `poseError` in `apps/demo/benchmarking.cpp::runBenchmarkTests` was overwritten every inner-loop iteration instead of accumulated, then `avgPoseError` divided that single leftover residual by the full `ITERATIONS * m_numIkSol` count — the reported average was structurally near-zero regardless of the solver's true accuracy.

## Fix
- Added a `sumAbsPoseError` accumulator (component-wise **absolute value**, so opposite-sign residuals don't cancel), summed across every valid IK solution's FK-vs-target residual.
- Divide by `fkCalls` — the true number of samples actually summed — mirroring how `avgFwdKin_us` already uses `fkCalls`.
- Output now reports **position (m)** and **orientation (rad)** error on separate labeled lines instead of one undifferentiated 6-number blob.

## Acceptance criteria (from #55)
- [x] Average pose error is summed over all valid solutions and divided by the true count.
- [x] Residuals are accumulated as magnitudes so opposite-sign errors don't cancel.
- [x] Output distinguishes position (m) and orientation (rad) error.

## Verification
- `cmake --build` (Release) succeeds.
- `ctest` (Release): **51/51 golden tests pass**, unchanged — this file isn't covered by golden tests directly, as expected.
- Ran the demo binary to eyeball the fixed metric on a 100k-iteration UR5 run:
  ```
  average position error (m): 5.26469e-08 4.75655e-08 7.63529e-08
  average orientation error (rad): 1.97223 2.12263 0.880645
  ```

## Note on the orientation-error number
Position error is now a plausible small number (~1e-7 m, essentially float noise), confirming the fix works and that FK/IK are internally consistent.

Orientation error is **not** small, and I want to flag why rather than let the number look alarming: I wrote a small standalone diagnostic (not part of this PR) that prints, per sample, the raw Euler-angle triples being diffed. Position error for every individual sample is ~1e-7 m, but the Euler-angle triple computed for the *input* pose and the triple computed for the *IK-solution-reconstructed* pose are consistently different — and *all valid solutions within a given trial agree with each other* on the alternate triple. This is the well-known two-fold representation ambiguity of Euler angles: a single rotation matrix decomposes into two distinct, equally valid `(α, β, γ)` triples, and which one `Eigen::eulerAngles` returns depends on which branch the matrix falls into, not on the rotation's actual magnitude. So the *physical* orientation is reproduced correctly (position confirms this), but raw component-wise `|Δeuler|` is not a rotation-invariant distance and can read large purely from a representation-branch mismatch.

This is a pre-existing property of comparing raw Euler-angle components, not something introduced or fixed by this PR — the old code never surfaced it because the divide-by-huge-count bug made the printed number ≈0 regardless. I've kept this PR strictly scoped to the accumulation bug per #55's acceptance criteria (all three are met). If a rotation-invariant orientation metric (e.g. quaternion angular distance or a wrapped/shortest-angle diff) is wanted, that reads like a separate, deliberately scoped follow-up — happy to file it if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark pose-error reporting by calculating mean absolute position and orientation differences across valid solutions.
  * Excluded invalid inverse-kinematics/forward-kinematics results from average error calculations.
  * Updated benchmark output labels and formatting to clearly describe the reported error metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->