### PR TITLE
refactor: remove dead code, return sized views from getTransZ/getTransX (#62)

### DIFF
--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -156,16 +156,6 @@ namespace universalRobots
 		Eigen::Matrix4f m_generalTransformationMatrices[m_numReferenceFrames] = {};
 
 		/**
-		 * @brief This boolean indicates whether a tool is/isnt attached to the robot.
-		 *
-		 * Must be specified in the constructor, if not default is false.
-		 * Currently stored but not read anywhere (endEffectorDimension alone drives
-		 * forwardKinematics); kept for API/ABI stability rather than removed, since
-		 * that's a behavior question out of scope for a lint-only change.
-		 */
-		[[maybe_unused]] bool m_endEffector = false;
-
-		/**
 		 * @brief Modified Denavit-Hartenberg parameters matrix (9x4)
 		 * { alpha_i-1, a_i-1, d_i, theta_i } for each frame.
 		 *
@@ -189,10 +179,9 @@ namespace universalRobots
 
 	  private:
 		void setMDHmatrix();
-		void setRobotType(URtype type);
 		void setTheta(const JointVector& jointVal);
-		[[nodiscard]] const float* getTransZ() const;
-		[[nodiscard]] const float* getTransX() const;
+		[[nodiscard]] const std::array<float, m_numTransZ>& getTransZ() const;
+		[[nodiscard]] const std::array<float, m_numTransX>& getTransX() const;
 		[[nodiscard]] float getTheta(int ix) const;
 		// `pose` is 6 floats (24 bytes), trivially copyable; a const-reference
 		// return would couple the caller to this object's lifetime for no

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -48,12 +48,13 @@ namespace
 namespace universalRobots
 {
 	/// <summary>
-	/// Constructor. User is only allowed to specify whether there is an end-effector and its translation to the tip.
+	/// Constructor. The endEffector parameter is retained for API compatibility but unused;
+	/// the end-effector translation to the tip is applied unconditionally via endEffectorDimension.
 	/// Example usage:
-	///		universalRobots::UR robot_one(); Robot does not have an end-effector.
+	///		universalRobots::UR robot_one();
 	///		universalRobots::UR robot_one(true, 0.15f); End-effector translated 0.15 meters from the robot's tip.
 	/// </summary>
-	/// <param name="endEffector"></param>
+	/// <param name="endEffector">Retained for API compatibility (unused).</param>
 	/// <param name="endEffectorDimension"></param>
 	UR::UR(URtype robotType, [[maybe_unused]] bool endEffector, float endEffectorDimension) : m_type(robotType)
 	{

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -55,8 +55,7 @@ namespace universalRobots
 	/// </summary>
 	/// <param name="endEffector"></param>
 	/// <param name="endEffectorDimension"></param>
-	UR::UR(URtype robotType, bool endEffector, float endEffectorDimension)
-		: m_type(robotType), m_endEffector(endEffector)
+	UR::UR(URtype robotType, [[maybe_unused]] bool endEffector, float endEffectorDimension) : m_type(robotType)
 	{
 		const RobotParameters& params = parametersFor(robotType);
 		m_d = params.d;
@@ -64,15 +63,6 @@ namespace universalRobots
 
 		m_d[m_numTransZ - 1] = endEffectorDimension;
 		setMDHmatrix();
-	}
-
-	/// <summary>
-	/// setRobotType
-	/// </summary>
-	/// <param name="type"></param>
-	void UR::setRobotType(URtype type)
-	{
-		m_type = type;
 	}
 
 	/// <summary>
@@ -114,18 +104,18 @@ namespace universalRobots
 	/// Returns the values of the z-axis translations (d array). Used for printing purposes.
 	/// </summary>
 	/// <returns>m_d</returns>
-	const float* UR::getTransZ() const
+	const std::array<float, UR::m_numTransZ>& UR::getTransZ() const
 	{
-		return m_d.data();
+		return m_d;
 	}
 
 	/// <summary>
 	/// Returns the values of the x-axis translations (a array). Used for printing purposes.
 	/// </summary>
 	/// <returns>m_a</returns>
-	const float* UR::getTransX() const
+	const std::array<float, UR::m_numTransX>& UR::getTransX() const
 	{
-		return m_a.data();
+		return m_a;
 	}
 
 	/// <summary>
@@ -499,11 +489,13 @@ namespace universalRobots
 	{
 		stream << "Link dimensions\n"
 			   << "Translations in the z-axis (meters):\n";
-		for (unsigned int i = 0; i < UR::m_numTransZ; i++)
-			stream << "d" << i + 1 << ": " << robot.m_d[i] << '\n';
+		unsigned int dIndex = 1;
+		for (float d : robot.getTransZ())
+			stream << "d" << dIndex++ << ": " << d << '\n';
 		stream << "Translations in the x-axis (meters):\n";
-		for (unsigned int i = 0; i < UR::m_numTransX; i++)
-			stream << "a" << i + 2 << ": " << robot.m_a[i] << '\n';
+		unsigned int aIndex = 2;
+		for (float a : robot.getTransX())
+			stream << "a" << aIndex++ << ": " << a << '\n';
 	}
 
 	void UR::printJointValues(std::ostream& stream, const UR& robot)


### PR DESCRIPTION
## Summary
Three items from #62, all scoped as directed:

1. **Remove `UR::setRobotType(URtype)`** — dead private method (`src/ur_kinematics.cpp:73-76` pre-refactor); no callers anywhere in the repo (grepped tests/apps/src/include). The constructor already sets `m_type` directly.
2. **Remove `m_endEffector`** — write-only private member, set in the constructor's init list but never read anywhere (`endEffectorDimension` alone drives `forwardKinematics` geometry — confirmed via grep, only that float param feeds `m_d[m_numTransZ - 1]`). The public `endEffector` constructor parameter is kept as-is (no public-API/ABI change), now marked `[[maybe_unused]]` since it's no longer stored into anything.
3. **`getTransZ()`/`getTransX()` now return sized views** — changed from `const float*` (discarding size) to `const std::array<float, m_numTransZ>&` / `const std::array<float, m_numTransX>&`. `printLinkDimensions` (from #61) now calls these getters and iterates with range-for instead of indexing `robot.m_d`/`robot.m_a` directly against `UR::m_numTransZ`/`UR::m_numTransX` as loop bounds. `m_numTransZ`/`m_numTransX` themselves are still used elsewhere (array sizing, `m_d[m_numTransZ - 1]` in the ctor and in `forwardKinematics`), so they're kept.

Chose `const std::array<float, N>&` over `std::span<const float>` — zero-cost, keeps `N` in the type, and matches how the member is already declared, so no extra include/dependency.

## Verification (hard gates)
- **Byte-identical output:** same method as #61 — `git stash` back to pre-#62 main (`a47d78a`), rebuild, capture `ur_demo`'s deterministic robot-print section (everything before the `Benchmarking...` banner; the benchmark section uses unseeded RNG and is unrelated), `git stash pop`, rebuild, capture again, diff. **Diff is empty.**
- **Golden tests:** `ctest` — **51/51 passing**, both before and after.
- Build: Release, MSVC, clean, no new warnings.

Fixes #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved access to robot link translation data through safer, structured collections.
  * Removed unused internal state and obsolete robot-type handling.
  * Preserved constructor compatibility while ignoring the unused end-effector flag.
  * Updated link-dimension output to use the revised translation data accessors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->