### PR TITLE
refactor: std::-qualify <cmath> calls, explicit includes, safe pow(x,2)->x*x (#58)

### DIFF
--- a/src/math_utils.cpp
+++ b/src/math_utils.cpp
@@ -2,6 +2,7 @@
 
 #include "math_utils.h"
 #include <ur_kinematics/ur_kinematics.h>
+#include <cmath>
 #include <numbers>
 
 namespace universalRobots
@@ -21,10 +22,11 @@ namespace universalRobots
 	Eigen::Matrix4f calcTransformationMatrix(const Eigen::RowVector4f& DHparams)
 	{
 		Eigen::Matrix4f individualTransformationMatrix;
-		individualTransformationMatrix << cos(DHparams[3]), -sin(DHparams[3]), 0, DHparams[1],
-			(sin(DHparams[3]) * cos(DHparams[0])), (cos(DHparams[3]) * cos(DHparams[0])), -sin(DHparams[0]),
-			(-sin(DHparams[0]) * DHparams[2]), (sin(DHparams[3]) * sin(DHparams[0])),
-			(cos(DHparams[3]) * sin(DHparams[0])), cos(DHparams[0]), (cos(DHparams[0]) * DHparams[2]), 0, 0, 0, 1;
+		individualTransformationMatrix << std::cos(DHparams[3]), -std::sin(DHparams[3]), 0, DHparams[1],
+			(std::sin(DHparams[3]) * std::cos(DHparams[0])), (std::cos(DHparams[3]) * std::cos(DHparams[0])),
+			-std::sin(DHparams[0]), (-std::sin(DHparams[0]) * DHparams[2]),
+			(std::sin(DHparams[3]) * std::sin(DHparams[0])), (std::cos(DHparams[3]) * std::sin(DHparams[0])),
+			std::cos(DHparams[0]), (std::cos(DHparams[0]) * DHparams[2]), 0, 0, 0, 1;
 
 		return individualTransformationMatrix;
 	}

--- a/src/math_utils.cpp
+++ b/src/math_utils.cpp
@@ -21,12 +21,15 @@ namespace universalRobots
 
 	Eigen::Matrix4f calcTransformationMatrix(const Eigen::RowVector4f& DHparams)
 	{
+		const float cos_dh0 = std::cos(DHparams[0]);
+		const float sin_dh0 = std::sin(DHparams[0]);
+		const float cos_dh3 = std::cos(DHparams[3]);
+		const float sin_dh3 = std::sin(DHparams[3]);
+
 		Eigen::Matrix4f individualTransformationMatrix;
-		individualTransformationMatrix << std::cos(DHparams[3]), -std::sin(DHparams[3]), 0, DHparams[1],
-			(std::sin(DHparams[3]) * std::cos(DHparams[0])), (std::cos(DHparams[3]) * std::cos(DHparams[0])),
-			-std::sin(DHparams[0]), (-std::sin(DHparams[0]) * DHparams[2]),
-			(std::sin(DHparams[3]) * std::sin(DHparams[0])), (std::cos(DHparams[3]) * std::sin(DHparams[0])),
-			std::cos(DHparams[0]), (std::cos(DHparams[0]) * DHparams[2]), 0, 0, 0, 1;
+		individualTransformationMatrix << cos_dh3, -sin_dh3, 0, DHparams[1], (sin_dh3 * cos_dh0), (cos_dh3 * cos_dh0),
+			-sin_dh0, (-sin_dh0 * DHparams[2]), (sin_dh3 * sin_dh0), (cos_dh3 * sin_dh0), cos_dh0,
+			(cos_dh0 * DHparams[2]), 0, 0, 0, 1;
 
 		return individualTransformationMatrix;
 	}

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -243,7 +243,7 @@ namespace universalRobots
 		const Eigen::Matrix<float, 1, 4> P_05 =
 			T_07 * Eigen::Matrix<float, 1, 4>(0.0f, 0.0f, -m_d[5] - m_d[6], 1.0f)
 					   .transpose(); // 0P5 position of reference frame {5} in relation to {0}
-		const float theta1_psi = atan2(P_05(0, 1), P_05(0, 0));
+		const float theta1_psi = std::atan2(P_05(0, 1), P_05(0, 0));
 
 		// There are two possible solutions for theta1, that depend on whether the shoulder joint (joint 2) is left or
 		// right. acos site 1: theta1_phi — if |arg| > 1+eps, all 8 solutions are invalid. NOTE: the domain check below
@@ -252,14 +252,16 @@ namespace universalRobots
 		// rounding step that, right at this near-singular domain edge (|arg|≈1, where d(acos)/dx diverges), measurably
 		// shifts the result vs the golden baseline. Keeping the acos() call on the untouched inline expression
 		// preserves bit-identical valid-row output.
-		const bool phi_inDomain = std::abs((m_d[1] + m_d[2] + m_d[3] + m_d[4]) /
-										   (sqrt(pow(P_05(0, 1), 2) + pow(P_05(0, 0), 2)))) <= 1.0 + kAcosEps;
+		const bool phi_inDomain =
+			std::abs((m_d[1] + m_d[2] + m_d[3] + m_d[4]) /
+					 (std::sqrt(std::pow(P_05(0, 1), 2) + std::pow(P_05(0, 0), 2)))) <= 1.0 + kAcosEps;
 		if (!phi_inDomain)
 			outIkSols.valid.fill(false);
 		const float theta1_phi =
 			phi_inDomain
-				? acos(std::clamp((m_d[1] + m_d[2] + m_d[3] + m_d[4]) / (sqrt(pow(P_05(0, 1), 2) + pow(P_05(0, 0), 2))),
-								  -1.0, 1.0))
+				? std::acos(std::clamp((m_d[1] + m_d[2] + m_d[3] + m_d[4]) /
+											(std::sqrt(std::pow(P_05(0, 1), 2) + std::pow(P_05(0, 0), 2))),
+									  -1.0, 1.0))
 				: std::numeric_limits<float>::quiet_NaN();
 
 		for (int i = -4; i < int(m_numIkSol) - 4; i++)
@@ -283,7 +285,7 @@ namespace universalRobots
 			const float t5_arg = (T_16(1, 3) - (m_d[1] + m_d[2] + m_d[3] + m_d[4])) / m_d[5];
 			if (std::abs(t5_arg) <= 1.0f + kAcosEps)
 			{
-				const float t5 = acos(std::clamp(t5_arg, -1.0f, 1.0f));
+				const float t5 = std::acos(std::clamp(t5_arg, -1.0f, 1.0f));
 				outIkSols.solutions[i][4] = contains(kWristUpSolutionIndices, i) ? t5 : -t5;
 			}
 			else
@@ -324,9 +326,10 @@ namespace universalRobots
 				outIkSols.solutions[i][5] = 0.0f;		  // Wrist singularity: theta6 pinned to 0 by convention.
 			else
 			{
-				const float sinTheta5 = sin(theta5);
-				outIkSols.solutions[i][5] = std::numbers::pi_v<float> / 2 +
-											atan2(-T_16.inverse()(1, 1) / sinTheta5, T_16.inverse()(0, 1) / sinTheta5);
+				const float sinTheta5 = std::sin(theta5);
+				outIkSols.solutions[i][5] =
+					std::numbers::pi_v<float> / 2 +
+					std::atan2(-T_16.inverse()(1, 1) / sinTheta5, T_16.inverse()(0, 1) / sinTheta5);
 			}
 
 			// Computing theta3, theta2, and theta4.
@@ -348,19 +351,23 @@ namespace universalRobots
 			Eigen::Matrix4f T_46 = T_45 * T_56;
 			Eigen::Matrix4f T_14 = T_16 * T_46.inverse();
 
-			float P_14_xz = sqrtf(pow(T_14(0, 3), 2) + pow(T_14(2, 3), 2));
+			const float T_14_x = T_14(0, 3);
+			const float T_14_z = T_14(2, 3);
+			float P_14_xz = std::sqrt(T_14_x * T_14_x + T_14_z * T_14_z);
 
 			// acos site 3: theta3_psi — if |arg| > 1+eps, solution i is invalid.
 			// See the site-1 note above: acos() is called on the untouched inline expression
 			// (clamped with double bounds) rather than a materialized float intermediate, to
 			// avoid an extra precision-losing rounding step right at this near-singular edge.
-			const bool psi_inDomain = std::abs((pow(P_14_xz, 2) - pow(m_a[1], 2) - pow(m_a[0], 2)) /
-											   (-2 * m_a[0] * m_a[1])) <= 1.0 + kAcosEps;
+			const bool psi_inDomain =
+				std::abs((std::pow(P_14_xz, 2) - std::pow(m_a[1], 2) - std::pow(m_a[0], 2)) /
+						 (-2 * m_a[0] * m_a[1])) <= 1.0 + kAcosEps;
 			if (!psi_inDomain)
 				outIkSols.valid[i] = false;
 			const float theta3_psi =
 				psi_inDomain
-					? acos(std::clamp((pow(P_14_xz, 2) - pow(m_a[1], 2) - pow(m_a[0], 2)) / (-2 * m_a[0] * m_a[1]),
+					? std::acos(std::clamp((std::pow(P_14_xz, 2) - std::pow(m_a[1], 2) - std::pow(m_a[0], 2)) /
+												(-2 * m_a[0] * m_a[1]),
 									  -1.0, 1.0))
 					: std::numeric_limits<float>::quiet_NaN();
 
@@ -373,8 +380,8 @@ namespace universalRobots
 				if (outIkSols.solutions[i][2] > std::numbers::pi_v<float>)
 					outIkSols.solutions[i][2] = outIkSols.solutions[i][2] - std::numbers::pi_v<float> * 2;
 				// Computing theta2.
-				outIkSols.solutions[i][1] = std::numbers::pi_v<float> / 2 - atan2(T_14(2, 3), T_14(0, 3)) +
-											asin((m_a[1] * sin(-theta3_psi)) / P_14_xz);
+				outIkSols.solutions[i][1] = std::numbers::pi_v<float> / 2 - std::atan2(T_14(2, 3), T_14(0, 3)) +
+											std::asin((m_a[1] * std::sin(-theta3_psi)) / P_14_xz);
 				// Computing theta4.
 				Eigen::Matrix4f T_12 = universalRobots::calcTransformationMatrix(
 					Eigen::RowVector4f(-std::numbers::pi_v<float> / 2, 0.0f, m_d[1],
@@ -386,7 +393,7 @@ namespace universalRobots
 				Eigen::Matrix4f T_36 = T_03.inverse() * T_06;
 				Eigen::Matrix4f T_34 = T_36 * T_46.inverse();
 
-				outIkSols.solutions[i][3] = atan2(T_34(1, 0), T_34(0, 0));
+				outIkSols.solutions[i][3] = std::atan2(T_34(1, 0), T_34(0, 0));
 			}
 			else
 			{
@@ -396,8 +403,8 @@ namespace universalRobots
 				if (outIkSols.solutions[i][2] > std::numbers::pi_v<float>)
 					outIkSols.solutions[i][2] = outIkSols.solutions[i][2] - std::numbers::pi_v<float> * 2;
 				// Computing theta2.
-				outIkSols.solutions[i][1] = std::numbers::pi_v<float> / 2 - atan2(T_14(2, 3), T_14(0, 3)) +
-											asin(m_a[1] * sin(theta3_psi) / P_14_xz);
+				outIkSols.solutions[i][1] = std::numbers::pi_v<float> / 2 - std::atan2(T_14(2, 3), T_14(0, 3)) +
+											std::asin(m_a[1] * std::sin(theta3_psi) / P_14_xz);
 				// Computing theta4.
 				Eigen::Matrix4f T_12 = universalRobots::calcTransformationMatrix(
 					Eigen::RowVector4f(-std::numbers::pi_v<float> / 2, 0.0f, m_d[1],
@@ -409,7 +416,7 @@ namespace universalRobots
 				Eigen::Matrix4f T_36 = T_03.inverse() * T_06;
 				Eigen::Matrix4f T_34 = T_36 * T_46.inverse();
 
-				outIkSols.solutions[i][3] = atan2(T_34(1, 0), T_34(0, 0));
+				outIkSols.solutions[i][3] = std::atan2(T_34(1, 0), T_34(0, 0));
 			}
 		}
 

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -258,11 +258,10 @@ namespace universalRobots
 		if (!phi_inDomain)
 			outIkSols.valid.fill(false);
 		const float theta1_phi =
-			phi_inDomain
-				? std::acos(std::clamp((m_d[1] + m_d[2] + m_d[3] + m_d[4]) /
-											(std::sqrt(std::pow(P_05(0, 1), 2) + std::pow(P_05(0, 0), 2))),
-									  -1.0, 1.0))
-				: std::numeric_limits<float>::quiet_NaN();
+			phi_inDomain ? std::acos(std::clamp((m_d[1] + m_d[2] + m_d[3] + m_d[4]) /
+													(std::sqrt(std::pow(P_05(0, 1), 2) + std::pow(P_05(0, 0), 2))),
+												-1.0, 1.0))
+						 : std::numeric_limits<float>::quiet_NaN();
 
 		for (int i = -4; i < int(m_numIkSol) - 4; i++)
 		{
@@ -359,17 +358,15 @@ namespace universalRobots
 			// See the site-1 note above: acos() is called on the untouched inline expression
 			// (clamped with double bounds) rather than a materialized float intermediate, to
 			// avoid an extra precision-losing rounding step right at this near-singular edge.
-			const bool psi_inDomain =
-				std::abs((std::pow(P_14_xz, 2) - std::pow(m_a[1], 2) - std::pow(m_a[0], 2)) /
-						 (-2 * m_a[0] * m_a[1])) <= 1.0 + kAcosEps;
+			const bool psi_inDomain = std::abs((std::pow(P_14_xz, 2) - std::pow(m_a[1], 2) - std::pow(m_a[0], 2)) /
+											   (-2 * m_a[0] * m_a[1])) <= 1.0 + kAcosEps;
 			if (!psi_inDomain)
 				outIkSols.valid[i] = false;
 			const float theta3_psi =
-				psi_inDomain
-					? std::acos(std::clamp((std::pow(P_14_xz, 2) - std::pow(m_a[1], 2) - std::pow(m_a[0], 2)) /
-												(-2 * m_a[0] * m_a[1]),
-									  -1.0, 1.0))
-					: std::numeric_limits<float>::quiet_NaN();
+				psi_inDomain ? std::acos(std::clamp((std::pow(P_14_xz, 2) - std::pow(m_a[1], 2) - std::pow(m_a[0], 2)) /
+														(-2 * m_a[0] * m_a[1]),
+													-1.0, 1.0))
+							 : std::numeric_limits<float>::quiet_NaN();
 
 			// Elbow up or down
 			if (contains(kSecondElbowSolutionIndices, i))
@@ -380,7 +377,7 @@ namespace universalRobots
 				if (outIkSols.solutions[i][2] > std::numbers::pi_v<float>)
 					outIkSols.solutions[i][2] = outIkSols.solutions[i][2] - std::numbers::pi_v<float> * 2;
 				// Computing theta2.
-				outIkSols.solutions[i][1] = std::numbers::pi_v<float> / 2 - std::atan2(T_14(2, 3), T_14(0, 3)) +
+				outIkSols.solutions[i][1] = std::numbers::pi_v<float> / 2 - std::atan2(T_14_z, T_14_x) +
 											std::asin((m_a[1] * std::sin(-theta3_psi)) / P_14_xz);
 				// Computing theta4.
 				Eigen::Matrix4f T_12 = universalRobots::calcTransformationMatrix(
@@ -403,7 +400,7 @@ namespace universalRobots
 				if (outIkSols.solutions[i][2] > std::numbers::pi_v<float>)
 					outIkSols.solutions[i][2] = outIkSols.solutions[i][2] - std::numbers::pi_v<float> * 2;
 				// Computing theta2.
-				outIkSols.solutions[i][1] = std::numbers::pi_v<float> / 2 - std::atan2(T_14(2, 3), T_14(0, 3)) +
+				outIkSols.solutions[i][1] = std::numbers::pi_v<float> / 2 - std::atan2(T_14_z, T_14_x) +
 											std::asin(m_a[1] * std::sin(theta3_psi) / P_14_xz);
 				// Computing theta4.
 				Eigen::Matrix4f T_12 = universalRobots::calcTransformationMatrix(


### PR DESCRIPTION
Closes #58.

## Scope
1. Added explicit `#include <cmath>` to `src/math_utils.cpp` (previously relied on a transitive include via Eigen/`<numbers>`). `src/ur_kinematics.cpp` already had it.
2. `std::`-qualified every `cos`/`sin`/`sqrt`/`sqrtf`/`pow`/`acos`/`atan2`/`asin` call in both translation units (was relying on the non-standard global-namespace fallback that `<math.h>` injects).
3. Replaced `pow(x, 2)` squaring with `x*x` **only where verified bit-identical** against the golden IK suite.

## Hard gate: golden FK/IK bit-identity (per issue #58)
This is a pure refactor; golden ctest must stay 51/51 bit-identical. It did not on the first mechanical pass — isolated per-site:

- **`P_14_xz` (was `sqrtf(pow(x,2)+pow(z,2))`)** → converted to `std::sqrt(x*x + z*z)`. Verified bit-identical, kept as multiplication.
- **`theta1_phi`/`phi_inDomain`** (site 1) and **`theta3_psi`/`psi_inDomain`** (site 3) — converting these to `x*x` broke golden bit-identity (UR5 joint 4/theta5 off by ~4.4e-4, UR10 joint 2/3 off by ~1.9e-4 and ~1e-4, both well past `ikTol=1e-4`). Root cause: `pow(float, int)` promotes to `double` per the standard's mixed-type overload rules, so the original code was implicitly computing these squarings in double precision; `x*x` on `float` operands computes in float precision instead, and these two sites feed directly into `acos()` domain checks right at the near-singular boundaries this solver is already documented (in-file comments) to be sensitive to.
  - **Reverted these two sites to `std::pow(x, 2)`** (kept the `std::` qualification, dropped only the `x*x` substitution) to preserve the double-precision promotion and bit-identical output.

Golden ctest: 51/51 passing, bit-identical, after the final state (P_14_xz as `x*x`, the other two sites as `std::pow`).

## Verification
- `cmake --build build --config Release -j` — clean build, no warnings introduced.
- `ctest -C Release --output-on-failure` — 51/51 passing.
- Manual isolation: reverted each pow site one at a time to confirm exactly which one(s) caused the shift before settling on the final combination above.

No self-merge; awaiting review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability and consistency of transformation matrix calculations.
  * Enhanced inverse kinematics calculations across joint, elbow, and wrist configurations.
  * Improved handling of trigonometric and numeric edge cases, including wrist singularities and solution validity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->