### PR TITLE
refactor: const-correctness for FK/IK queries (#59)

### DIFF
--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -148,6 +148,9 @@ namespace universalRobots
 		// logically const (its return value depends only on its argument and the
 		// robot's fixed DH parameters); mutable lets it also refresh this cache
 		// without losing const-callability. See forwardKinematics()'s doc comment.
+		// Not thread-safe: the cache is updated without synchronization, so
+		// concurrent const calls (e.g. forwardKinematics()) on the same UR
+		// instance from multiple threads is a data race.
 
 		/** @brief Position, Euler Angles, and Value of the robot's joints. {x, y, z} {alpha, beta, gamma} {jointValue}
 		 */

--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -143,17 +143,23 @@ namespace universalRobots
 		 */
 		std::array<float, m_numTransX> m_a = kUR10.a;
 
+		// mutable: these four members are a cache of the last forwardKinematics()
+		// computation, kept for operator<</pose accessors. forwardKinematics() is
+		// logically const (its return value depends only on its argument and the
+		// robot's fixed DH parameters); mutable lets it also refresh this cache
+		// without losing const-callability. See forwardKinematics()'s doc comment.
+
 		/** @brief Position, Euler Angles, and Value of the robot's joints. {x, y, z} {alpha, beta, gamma} {jointValue}
 		 */
-		joint m_jointState[m_numDoF] = {};
+		mutable joint m_jointState[m_numDoF] = {};
 
 		// Create an array of (individual) transformation matrices iTi+1 / i-1Ti
 
 		/** @brief Array of (individual) transformation matrices iTi+1 / i-1Ti */
-		Eigen::Matrix4f m_individualTransformationMatrices[m_numReferenceFrames] = {};
+		mutable Eigen::Matrix4f m_individualTransformationMatrices[m_numReferenceFrames] = {};
 
 		/** @brief Array of (general) transformation matrices 0Ti */
-		Eigen::Matrix4f m_generalTransformationMatrices[m_numReferenceFrames] = {};
+		mutable Eigen::Matrix4f m_generalTransformationMatrices[m_numReferenceFrames] = {};
 
 		/**
 		 * @brief Modified Denavit-Hartenberg parameters matrix (9x4)
@@ -161,25 +167,28 @@ namespace universalRobots
 		 *
 		 * Populated by setMDHmatrix() from the constructor.
 		 */
-		Eigen::Matrix<float, m_numReferenceFrames, 4> m_MDHmatrix;
+		mutable Eigen::Matrix<float, m_numReferenceFrames, 4> m_MDHmatrix;
 
 	  public:
 		UR(URtype robotType = UR10, bool endEffector = false, float endEffectorDimension = 0.0f);
 		[[nodiscard]] URtype getRobotType() const;
 		/// Precondition: every joint value must be finite and in [-2π, 2π].
 		/// Throws std::invalid_argument otherwise.
-		[[nodiscard]] pose forwardKinematics(const JointVector& targetJointVal);
-		[[nodiscard]] IkSolutions inverseKinematics(const pose& targetTipPose);
+		/// Note: also refreshes the joint-pose/transform cache used by operator<<
+		/// and the joint-pose accessors (see the mutable members above) -- callable
+		/// on a const UR, but not side-effect-free with respect to that cache.
+		[[nodiscard]] pose forwardKinematics(const JointVector& targetJointVal) const;
+		[[nodiscard]] IkSolutions inverseKinematics(const pose& targetTipPose) const;
 		/// Returns true iff inverseKinematics(targetPose).anyValid().
-		[[nodiscard]] bool isPoseReachable(const pose& targetPose);
-		pose generateRandomReachablePose();
+		[[nodiscard]] bool isPoseReachable(const pose& targetPose) const;
+		pose generateRandomReachablePose() const;
 		[[nodiscard]] static bool isSolutionValid(const std::array<float, m_numDoF>& ikSolution);
 		friend std::ostream& operator<<(std::ostream& stream, const universalRobots::UR& robot);
 		friend std::ostream& operator<<(std::ostream& stream, universalRobots::URtype type);
 
 	  private:
-		void setMDHmatrix();
-		void setTheta(const JointVector& jointVal);
+		void setMDHmatrix() const;
+		void setTheta(const JointVector& jointVal) const;
 		[[nodiscard]] const std::array<float, m_numTransZ>& getTransZ() const;
 		[[nodiscard]] const std::array<float, m_numTransX>& getTransX() const;
 		[[nodiscard]] float getTheta(int ix) const;

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -69,7 +69,7 @@ namespace universalRobots
 	/// <summary>
 	/// setMDHmatrix
 	///	</summary>
-	void UR::setMDHmatrix()
+	void UR::setMDHmatrix() const
 	{
 		m_MDHmatrix << 0.0f, 0.0f, m_d[0], m_jointState[0].m_jointValue,									   // 0T1
 			universalRobots::rad(-90), 0.0f, m_d[1], m_jointState[1].m_jointValue + universalRobots::rad(-90), // 1T2
@@ -86,7 +86,7 @@ namespace universalRobots
 	/// setTheta
 	/// </summary>
 	/// <param name="jointVal"></param>
-	void UR::setTheta(const JointVector& jointVal)
+	void UR::setTheta(const JointVector& jointVal) const
 	{
 		for (unsigned int i = 0; i < m_numDoF; i++)
 			m_jointState[i].m_jointValue = jointVal[i];
@@ -142,7 +142,7 @@ namespace universalRobots
 	/// </summary>
 	/// <param name="targetJointVal"></param>
 	/// <returns>tipPose</returns>
-	pose UR::forwardKinematics(const JointVector& targetJointVal)
+	pose UR::forwardKinematics(const JointVector& targetJointVal) const
 	{
 		constexpr float kTwoPi = 2.0f * std::numbers::pi_v<float>;
 		for (unsigned int i = 0; i < m_numDoF; ++i)
@@ -218,7 +218,7 @@ namespace universalRobots
 #pragma warning(push)
 #pragma warning(disable : 4244)
 #endif
-	UR::IkSolutions UR::inverseKinematics(const pose& targetTipPose)
+	UR::IkSolutions UR::inverseKinematics(const pose& targetTipPose) const
 	{
 		IkSolutions outIkSols = {};
 		outIkSols.valid.fill(true); // start optimistic; mark false at each failed acos site
@@ -423,7 +423,7 @@ namespace universalRobots
 #pragma warning(pop)
 #endif
 
-	bool UR::isPoseReachable(const pose& targetPose)
+	bool UR::isPoseReachable(const pose& targetPose) const
 	{
 		return inverseKinematics(targetPose).anyValid();
 	}
@@ -432,7 +432,7 @@ namespace universalRobots
 	/// Generates a valid tip pose by running forward kinematics with random target joint values.
 	/// </summary>
 	/// <returns>randomValidTargetPose</returns>
-	pose UR::generateRandomReachablePose()
+	pose UR::generateRandomReachablePose() const
 	{
 		//// https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution
 		std::random_device rd;

--- a/tests/test_sanity.cpp
+++ b/tests/test_sanity.cpp
@@ -18,3 +18,18 @@ TEST(Sanity, ForwardKinematicsRuns)
 	for (float p : tip.m_pos)
 		EXPECT_TRUE(std::isfinite(p));
 }
+
+// Issue #59: forwardKinematics()/inverseKinematics() are queries and must be
+// callable on a const UR (const-qualified even though FK still caches the
+// last-computed joint/transform state for operator<< via mutable members).
+TEST(Sanity, QueriesAreCallableOnConstRobot)
+{
+	const universalRobots::UR robot(universalRobots::URtype::UR5);
+	const universalRobots::UR::JointVector zeros = {0, 0, 0, 0, 0, 0};
+	const universalRobots::pose tip = robot.forwardKinematics(zeros);
+	for (float p : tip.m_pos)
+		EXPECT_TRUE(std::isfinite(p));
+
+	const universalRobots::UR::IkSolutions sols = robot.inverseKinematics(tip);
+	EXPECT_TRUE(sols.anyValid());
+}


### PR DESCRIPTION
Closes #59.

## Scope
Both `forwardKinematics()` and `inverseKinematics()` were `[[nodiscard]]` queries that secretly mutated members. This PR makes the mutation either non-existent or explicit, per the issue's acceptance criteria:

1. **`inverseKinematics` is `const`, callable on a `const UR&`.** It never touched any member state to begin with (only reads `m_d`/`m_a`, computes into locals) -- trivial, zero-risk change.
2. **`forwardKinematics`'s mutation is now explicit, not secret.** It caches the last-computed state (`m_jointState`, `m_MDHmatrix`, `m_individualTransformationMatrices`, `m_generalTransformationMatrices`) for `operator<<` and the joint-pose accessors to read afterward. Splitting that into a separate mutating method (e.g. `updateState()`) would require touching every FK call site (`apps/demo/main.cpp`, `generateRandomReachablePose()`, several tests) to preserve identical `operator<<` output -- more surface area for a golden/output mismatch for a purely structural refactor. Instead, the four cache members are marked `mutable`: FK's return value depends only on its argument and the robot's fixed DH parameters (logically const), and the `mutable` cache lets it keep refreshing that state without losing const-callability. Documented on the members and on FK's declaration.
3. **Added `Sanity.QueriesAreCallableOnConstRobot`** (`tests/test_sanity.cpp`): constructs a `const UR` and exercises both `forwardKinematics` and `inverseKinematics` on it.

As a natural extension with the same zero-risk profile, `isPoseReachable()` and `generateRandomReachablePose()` are also now `const` -- they only ever mutated state via calls to IK/FK, so once those are const there's no remaining reason for these to stay non-const. `setMDHmatrix()`/`setTheta()` (private helpers FK calls) become `const` to match, since they only write to the now-mutable cache members.

## Hard gate: pure structural refactor, zero numerical/observable change
- **Golden ctest 51/51 bit-identical** (52/52 total including the new sanity test).
- **`operator<<` output byte-identical**: git-stash technique (stash this refactor -> rebuild -> capture `ur_demo.exe`'s deterministic FK/IK section, i.e. everything before the randomized benchmarking section -> pop -> rebuild -> capture again -> diff). Empty diff.
- `clang-format --dry-run -Werror` clean.

## API/ABI
No public method removed or renamed. Existing non-const call sites are unaffected -- a `const`-qualified method remains callable on a non-const object, so no caller changes were needed.

No self-merge; awaiting review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kinematics queries can now be called on read-only robot instances, including forward and inverse kinematics, reachability checks, and random reachable pose generation.

* **Bug Fixes**
  * Improved const-instance compatibility while maintaining correct kinematics results.

* **Tests**
  * Added coverage verifying forward and inverse kinematics operate correctly on read-only robot instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->