### PR TITLE
refactor: replace raw C-arrays with std::array (#57)

### DIFF
--- a/docs/wiki/UR-Class-API.md
+++ b/docs/wiki/UR-Class-API.md
@@ -88,8 +88,8 @@ Returns `true` if none of the 6 joint values in `ikSolution` are NaN. This is wh
 ```cpp
 struct pose
 {
-    float m_pos[3];         // x, y, z (metres)
-    float m_eulerAngles[3]; // alpha, beta, gamma (radians, ZYX convention)
+    std::array<float, 3> m_pos;         // x, y, z (metres)
+    std::array<float, 3> m_eulerAngles; // alpha, beta, gamma (radians, ZYX convention)
 };
 ```
 

--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -43,11 +43,10 @@ namespace universalRobots
 		{
 		}
 
-		pose(const std::array<float, 3>& pos, const Eigen::Matrix3f& rotationMatrix)
-			: m_pos(pos),
-			  m_eulerAngles{rotationMatrix.eulerAngles(1, 2, 0).z(), rotationMatrix.eulerAngles(1, 2, 0).y(),
-							rotationMatrix.eulerAngles(1, 2, 0).x()}
+		pose(const std::array<float, 3>& pos, const Eigen::Matrix3f& rotationMatrix) : m_pos(pos)
 		{
+			const auto euler = rotationMatrix.eulerAngles(1, 2, 0);
+			m_eulerAngles = {euler.z(), euler.y(), euler.x()};
 		}
 
 		[[nodiscard]] pose divideByConst(float constant) const

--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -5,6 +5,7 @@
 #include <iosfwd>
 #include <array>
 #include <algorithm>
+#include <type_traits>
 #include <Eigen/Dense>
 #include "robot_parameters.h"
 #include <stdexcept>
@@ -21,8 +22,8 @@ namespace universalRobots
 	/** @brief Structure which holds a pose { x y z } { alpha beta gamma } */
 	struct pose
 	{
-		float m_pos[3] = {};		 // x y z (meters)
-		float m_eulerAngles[3] = {}; // alpha beta gamma (radians)
+		std::array<float, 3> m_pos = {};		 // x y z (meters)
+		std::array<float, 3> m_eulerAngles = {}; // alpha beta gamma (radians)
 
 		pose() = default;
 
@@ -37,13 +38,13 @@ namespace universalRobots
 
 		// Same rationale as above.
 		// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-		pose(const float (&pos)[3], const float (&eulerAngles)[3])
-			: m_pos{pos[0], pos[1], pos[2]}, m_eulerAngles{eulerAngles[0], eulerAngles[1], eulerAngles[2]}
+		pose(const std::array<float, 3>& pos, const std::array<float, 3>& eulerAngles)
+			: m_pos(pos), m_eulerAngles(eulerAngles)
 		{
 		}
 
-		pose(const float (&pos)[3], const Eigen::Matrix3f& rotationMatrix)
-			: m_pos{pos[0], pos[1], pos[2]},
+		pose(const std::array<float, 3>& pos, const Eigen::Matrix3f& rotationMatrix)
+			: m_pos(pos),
 			  m_eulerAngles{rotationMatrix.eulerAngles(1, 2, 0).z(), rotationMatrix.eulerAngles(1, 2, 0).y(),
 							rotationMatrix.eulerAngles(1, 2, 0).x()}
 		{
@@ -75,6 +76,10 @@ namespace universalRobots
 			return subtract(other);
 		}
 	};
+
+	// #57: m_pos/m_eulerAngles moved from float[3] to std::array<float,3>; pose
+	// must stay cheap to pass/return by value.
+	static_assert(std::is_trivially_copyable_v<pose>, "pose must remain trivially copyable");
 
 	/** @brief Structure which holds the current value and pose of a joint. */
 	struct joint
@@ -154,15 +159,15 @@ namespace universalRobots
 
 		/** @brief Position, Euler Angles, and Value of the robot's joints. {x, y, z} {alpha, beta, gamma} {jointValue}
 		 */
-		mutable joint m_jointState[m_numDoF] = {};
+		mutable std::array<joint, m_numDoF> m_jointState = {};
 
 		// Create an array of (individual) transformation matrices iTi+1 / i-1Ti
 
 		/** @brief Array of (individual) transformation matrices iTi+1 / i-1Ti */
-		mutable Eigen::Matrix4f m_individualTransformationMatrices[m_numReferenceFrames] = {};
+		mutable std::array<Eigen::Matrix4f, m_numReferenceFrames> m_individualTransformationMatrices = {};
 
 		/** @brief Array of (general) transformation matrices 0Ti */
-		mutable Eigen::Matrix4f m_generalTransformationMatrices[m_numReferenceFrames] = {};
+		mutable std::array<Eigen::Matrix4f, m_numReferenceFrames> m_generalTransformationMatrices = {};
 
 		/**
 		 * @brief Modified Denavit-Hartenberg parameters matrix (9x4)

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -186,8 +186,9 @@ namespace universalRobots
 					m_generalTransformationMatrices[i](2, 0), m_generalTransformationMatrices[i](2, 1),
 					m_generalTransformationMatrices[i](2, 2);
 
-				float position[3] = {m_generalTransformationMatrices[i](0, 3), m_generalTransformationMatrices[i](1, 3),
-									 m_generalTransformationMatrices[i](2, 3)};
+				std::array<float, 3> position = {m_generalTransformationMatrices[i](0, 3),
+												 m_generalTransformationMatrices[i](1, 3),
+												 m_generalTransformationMatrices[i](2, 3)};
 
 				// Tip pose
 				if (i == 8)


### PR DESCRIPTION
Closes #57.

## Scope
Pure type change, zero arithmetic touched, finishing what m_d/m_a/JointVector already started (#34):

- `pose::m_pos` / `m_eulerAngles`: `float[3]` -> `std::array<float,3>`.
- `pose`'s two array-taking constructors: `const float (&)[3]` -> `const std::array<float,3>&`.
- `UR::m_jointState`: `joint[m_numDoF]` -> `std::array<joint, m_numDoF>`.
- `UR::m_individualTransformationMatrices` / `m_generalTransformationMatrices`: `Eigen::Matrix4f[m_numReferenceFrames]` -> `std::array<Eigen::Matrix4f, m_numReferenceFrames>` (inline storage — the Eigen-in-`std::vector` aligned-allocator caveat does not apply to `std::array`).
- `src/ur_kinematics.cpp`'s one local `float position[3]` (the only call site in the repo feeding the array-taking `pose` constructors) converted alongside. Confirmed via a repo-wide sweep that no other file constructs a `pose` via these constructors or takes the address of any of these members — all other usages are `operator[]` indexing or range-for loops, both drop-in compatible with `std::array`.
- Added `static_assert(std::is_trivially_copyable_v<pose>)` documenting the pass-by-value cost guarantee acceptance criterion 2 asks to preserve.
- `docs/wiki/UR-Class-API.md`'s `pose` struct snippet updated to match (acceptance criterion 3).

## Acceptance criteria
1. No raw C-array data members remain in the public/private API. ✅
2. All tests pass and `pose` stays trivially copyable — enforced by the new `static_assert`. ✅
3. `docs/wiki/UR-Class-API.md` updated. ✅

## Hard gates
- Golden ctest **52/52 bit-identical** (the new #59 baseline: 51 original + 1 const-UR test).
- Byte-identical `operator<<` output confirmed via git-stash diff (empty diff — same methodology as #59/#61/#62).
- `pose` confirmed trivially copyable via `static_assert` (compiles).
- clang-format clean.

## Notes
- No public method renamed or removed.
- Layout of `std::array<float,3>` == `float[3]`, so `m_pos`/`m_eulerAngles` are effectively ABI-neutral. The two `pose` array-taking constructor parameter types are a **source-level** change (callers passing raw C-array literals would need to adapt) — not exercised in-repo since the sole call site was converted alongside.
- Per the dispatch's guidance, no compatibility overload was added for the old `const float (&)[3]` constructor signature: the only in-repo call site was updated directly, so the overload would have carried zero call-site benefit while adding permanent surface area.
- Did not touch `.clang-tidy`'s now-partially-stale comment/disable for `{modernize,cppcoreguidelines}-avoid-c-arrays` (it also covers other local C-arrays throughout `src`/`tests` outside this PR's scope, e.g. `tests/golden_generator.cpp`'s `float v[6]`) — flagging as a possible future cleanup, not acted on here to keep this diff surgical.

No self-merge; awaiting review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal pose and kinematics data handling to use modern fixed-size containers.
  * Preserved forward-kinematics calculations and pose results.
  * Added safeguards to ensure pose data remains efficiently transferable.
  * Updated pose construction interfaces for array-based position and orientation values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->