### PR TITLE
docs+test: characterize FK-extract/IK-compose Euler asymmetry (#54, Option A)

### DIFF
--- a/apps/demo/benchmarking.cpp
+++ b/apps/demo/benchmarking.cpp
@@ -1,11 +1,41 @@
 // benchmarking.cpp
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <Eigen/Dense>
 #include "benchmarking.h"
 
 namespace benchmark
 {
+	namespace
+	{
+		// Reconstructs the rotation matrix implied by a pose's stored Euler triple,
+		// using the SAME convention forwardKinematics()'s FK-extract uses (the
+		// pose(pos, Eigen::Matrix3f) ctor: eulerAngles(1,2,0) remapped to
+		// {gamma,beta,alpha} order), which Eigen guarantees is an exact inverse of
+		// that extraction. Both poses compared here (tipPoseInput and tipPoseOutput)
+		// come from forwardKinematics(), so this single convention applies to both --
+		// see #54.
+		Eigen::Matrix3f reconstructRotation(const universalRobots::pose& p)
+		{
+			return Eigen::Matrix3f(Eigen::AngleAxisf(p.m_eulerAngles[2], Eigen::Vector3f::UnitY()) *
+									Eigen::AngleAxisf(p.m_eulerAngles[1], Eigen::Vector3f::UnitZ()) *
+									Eigen::AngleAxisf(p.m_eulerAngles[0], Eigen::Vector3f::UnitX()));
+		}
+
+		// Rotation-invariant SO(3) geodesic distance (radians) between two rotation
+		// matrices. Unlike a raw Euler-component subtraction, this is not sensitive to
+		// the two-fold Euler representation ambiguity, so it reports honest orientation
+		// error (see #54).
+		float geodesicOrientationError(const universalRobots::pose& a, const universalRobots::pose& b)
+		{
+			const Eigen::Matrix3f relative = reconstructRotation(a).transpose() * reconstructRotation(b);
+			const float cosTheta = std::clamp((relative.trace() - 1.0f) / 2.0f, -1.0f, 1.0f);
+			return std::acos(cosTheta);
+		}
+	} // namespace
+
 	void runBenchmarkTests(universalRobots::UR& robot)
 	{
 		std::cout << "____________________________\nBenchmarking..." << '\n' << '\n';
@@ -14,7 +44,7 @@ namespace benchmark
 		universalRobots::pose tipPoseOutput = {};
 		universalRobots::pose poseError = {};
 		double sumAbsPos[3] = {0.0, 0.0, 0.0};
-		double sumAbsEuler[3] = {0.0, 0.0, 0.0};
+		double sumOrientationError = 0.0;
 		universalRobots::pose avgPoseError = {};
 
 		std::chrono::duration<double, std::micro> invKin_us{};
@@ -52,21 +82,18 @@ namespace benchmark
 				sumFwdKin_us = sumFwdKin_us + fwdKin_us;
 				poseError = tipPoseInput - tipPoseOutput;
 				for (unsigned int k = 0; k < 3; k++)
-				{
 					sumAbsPos[k] += std::abs(poseError.m_pos[k]);
-					sumAbsEuler[k] += std::abs(poseError.m_eulerAngles[k]);
-				}
+				sumOrientationError += geodesicOrientationError(tipPoseInput, tipPoseOutput);
 			}
 		}
 		avgInvKin_us = sumInvKin_us / ITERATIONS;
 		avgFwdKin_us = fkCalls > 0 ? sumFwdKin_us / fkCalls : std::chrono::duration<double, std::micro>::zero();
+		double avgOrientationError = 0.0;
 		if (fkCalls > 0)
 		{
 			for (unsigned int k = 0; k < 3; k++)
-			{
 				avgPoseError.m_pos[k] = static_cast<float>(sumAbsPos[k] / fkCalls);
-				avgPoseError.m_eulerAngles[k] = static_cast<float>(sumAbsEuler[k] / fkCalls);
-			}
+			avgOrientationError = sumOrientationError / fkCalls;
 		}
 
 		std::cout << "Generated " << ITERATIONS << " random valid tip poses for " << robot.getRobotType() << "..."
@@ -75,11 +102,13 @@ namespace benchmark
 		std::cout << "Average IK function execution time: " << avgInvKin_us.count() << "us" << '\n';
 		std::cout << "Each IK sol (" << fkCalls << ") has been run through forward kinematics..." << '\n';
 		std::cout << "Average FK function execution time: " << avgFwdKin_us.count() << "us" << '\n';
-		std::cout << "error = mean |tip_pose_input - tip_pose_output| over all valid IK solutions" << '\n';
+		std::cout << "position error = mean |tip_pose_input - tip_pose_output| over all valid IK solutions" << '\n';
 		std::cout << "average position error (m): " << avgPoseError.m_pos[0] << " " << avgPoseError.m_pos[1] << " "
 				  << avgPoseError.m_pos[2] << '\n';
-		std::cout << "average orientation error (rad): " << avgPoseError.m_eulerAngles[0] << " "
-				  << avgPoseError.m_eulerAngles[1] << " " << avgPoseError.m_eulerAngles[2] << '\n';
+		// Rotation-invariant SO(3) geodesic distance, not a raw Euler-component
+		// subtraction -- see #54 (quirk Q5: FK-extract / IK-compose Euler conventions
+		// are asymmetric, so a per-component Euler diff is not a meaningful metric).
+		std::cout << "average orientation error, SO(3) geodesic distance (rad): " << avgOrientationError << '\n';
 	}
 
 	std::chrono::microseconds timer::stop()

--- a/apps/demo/benchmarking.cpp
+++ b/apps/demo/benchmarking.cpp
@@ -19,9 +19,10 @@ namespace benchmark
 		// see #54.
 		Eigen::Matrix3f reconstructRotation(const universalRobots::pose& p)
 		{
-			return Eigen::Matrix3f(Eigen::AngleAxisf(p.m_eulerAngles[2], Eigen::Vector3f::UnitY()) *
-									Eigen::AngleAxisf(p.m_eulerAngles[1], Eigen::Vector3f::UnitZ()) *
-									Eigen::AngleAxisf(p.m_eulerAngles[0], Eigen::Vector3f::UnitX()));
+			const Eigen::AngleAxisf rotY(p.m_eulerAngles[2], Eigen::Vector3f::UnitY());
+			const Eigen::AngleAxisf rotZ(p.m_eulerAngles[1], Eigen::Vector3f::UnitZ());
+			const Eigen::AngleAxisf rotX(p.m_eulerAngles[0], Eigen::Vector3f::UnitX());
+			return Eigen::Matrix3f(rotY * rotZ * rotX);
 		}
 
 		// Rotation-invariant SO(3) geodesic distance (radians) between two rotation

--- a/docs/wiki/Kinematics-Theory.md
+++ b/docs/wiki/Kinematics-Theory.md
@@ -9,13 +9,13 @@ Given the 6 joint angles, forward kinematics is a straightforward chain of the 9
 1. Build the 9×4 MDH parameter matrix for the current joint values (`setMDHmatrix()`).
 2. Convert each row into an individual homogeneous transform `_{i-1}T_i` (`calcTransformationMatrix()`).
 3. Chain them left-to-right into general transforms `_0T_i = _0T_1 \cdot _1T_2 \cdots _{i-1}T_i`.
-4. `_0T_7` (frame 8) gives the tip's position and orientation directly; the position is the last column, and the orientation (Euler angles, ZYX) is extracted from the rotation block via `Eigen::Matrix3f::eulerAngles`.
+4. `_0T_7` (frame 8) gives the tip's position and orientation directly; the position is the last column, and the orientation (Euler angles) is extracted from the rotation block via `Eigen::Matrix3f::eulerAngles(1,2,0)`, remapped to `{alpha,beta,gamma}` such that `R = RotY(gamma)·RotZ(beta)·RotX(alpha)`.
 
 Along the way, the general transforms for the pose-bearing frames (0, 1, 2, 3, 5, 7 — corresponding to joints 1–6) are also captured as each joint's own pose, which is why `operator<<` can print every joint's position/orientation, not just the tip's.
 
 ## Inverse kinematics
 
-Given a target tip pose, the solver is **geometric** (closed-form), not iterative — it exploits the fact that the last three joint axes intersect at the wrist centre to decouple position from orientation, following the well-known Pieper approach for spherical-wrist manipulators (see refs. 3–5, 9 in `docs/REFERENCES.md`). It returns **up to 8 solutions**, corresponding to every combination of:
+Given a target tip pose, the solver **composes** a target rotation matrix from the pose's `(alpha,beta,gamma)` Euler triple as `R = RotX(alpha)·RotY(beta)·RotZ(gamma)` (note: this is a *different* convention from forward kinematics' extraction above — see [Euler convention asymmetry](#euler-convention-asymmetry-quirk-q5) below). The solver is **geometric** (closed-form), not iterative — it exploits the fact that the last three joint axes intersect at the wrist centre to decouple position from orientation, following the well-known Pieper approach for spherical-wrist manipulators (see refs. 3–5, 9 in `docs/REFERENCES.md`). It returns **up to 8 solutions**, corresponding to every combination of:
 
 - **Shoulder left / right** (`theta1`) — two solutions for the base rotation that place the wrist centre at the required horizontal distance from the base axis.
 - **Elbow up / down** (`theta3`, and consequently `theta2`, `theta4`) — two solutions for the elbow bend that reach a given wrist-centre position.
@@ -34,6 +34,10 @@ The solver computes several joint angles via `acos()` of a ratio derived from th
 ### Wrist singularity
 
 When `theta5` is 0 or ±π, the joint-6 rotation axis becomes (anti-)parallel to the joint-4 axis, and `theta6` becomes underdetermined (the usual formula divides by `sin(theta5) == 0`). By convention, this library pins `theta6 = 0` at that singularity and solves the remaining joints consistently for that choice — the wrist centre and orientation are still correct, just with one particular (arbitrary but repeatable) split between joints 4 and 6.
+
+### Euler convention asymmetry (quirk Q5)
+
+Forward kinematics *extracts* Euler angles from a rotation matrix as `R = RotY(gamma)·RotZ(beta)·RotX(alpha)`; inverse kinematics *composes* its target rotation matrix from the same `(alpha,beta,gamma)` triple as `R = RotX(alpha)·RotY(beta)·RotZ(gamma)`. These are two genuinely different conventions, not algebraic inverses of each other for a generic pose — not a two-fold Euler representation ambiguity. Consequently `inverseKinematics(forwardKinematics(q))` round-trips **position** exactly, but not orientation: an empirical sweep (issue #54; 500 iterations × 3 models × 8 solutions, seed 1337, 9148 valid samples) measured the rotation-invariant SO(3) geodesic distance between target and round-tripped orientation and found errors spanning the full `[0, π]` range with mean ≈1.52 rad — the statistical signature of two uncorrelated rotations, confirming a genuine convention mismatch. This is kept as documented v1.0 behavior for backward compatibility (human ruling on #54, 2026-07) rather than fixed, since fixing it would change the library's stored-Euler output contract and require a golden data re-baseline. When comparing orientations, prefer a rotation-invariant metric (e.g. the SO(3) geodesic distance, see `apps/demo/benchmarking.cpp`) over a raw per-component Euler diff.
 
 ### Getting a NaN-free solution
 

--- a/docs/wiki/UR-Class-API.md
+++ b/docs/wiki/UR-Class-API.md
@@ -89,11 +89,13 @@ Returns `true` if none of the 6 joint values in `ikSolution` are NaN. This is wh
 struct pose
 {
     std::array<float, 3> m_pos;         // x, y, z (metres)
-    std::array<float, 3> m_eulerAngles; // alpha, beta, gamma (radians, ZYX convention)
+    std::array<float, 3> m_eulerAngles; // alpha, beta, gamma (radians)
 };
 ```
 
 Constructible from position + Euler angles, or from position + an `Eigen::Matrix3f` rotation matrix. Supports `operator-` and `operator/` for computing pose errors (see [Benchmarking](Benchmarking)).
+
+**Euler convention caveat:** `m_eulerAngles` is not a single, consistent convention across the library. `forwardKinematics()` extracts it from the tip rotation matrix as `R = RotY(γ)·RotZ(β)·RotX(α)`, while `inverseKinematics()` composes its target rotation from the same triple as `R = RotX(α)·RotY(β)·RotZ(γ)` — these are two different conventions, not inverses of each other for a generic pose. As a result, `inverseKinematics(forwardKinematics(q))` round-trips **position** exactly but not orientation (quirk Q5; see [Kinematics Theory](Kinematics-Theory) and `tests/README.md`). When comparing orientations, use a rotation-invariant metric (e.g. the SO(3) geodesic distance) rather than a per-component Euler diff.
 
 ## Printing a robot
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -64,8 +64,23 @@ also written into each JSON header:
 | IK NaN pattern | exact (`null` ⇔ `std::isnan`) |
 | Round-trip: FK(IK solution).position vs target | `1e-4` m |
 
-Round-trip compares **position only** — the FK-extract / IK-compose Euler conventions
-are deliberately asymmetric (quirk Q5) and only round-trip through position.
+Round-trip compares **position only** — quirk **Q5**. The root cause is a genuine
+convention asymmetry, not merely a two-fold Euler representation ambiguity: the
+FK-extract (`pose(pos, Eigen::Matrix3f)` ctor, `include/ur_kinematics/ur_kinematics.h`
+lines 46-49) implies `R = RotY(e2)·RotZ(e1)·RotX(e0)`, while the IK-compose
+(`inverseKinematics()`, `src/ur_kinematics.cpp` lines 369-371) builds
+`R = RotX(e0)·RotY(e1)·RotZ(e2)` from the same stored `(e0,e1,e2)` triple — these are
+not algebraic inverses of each other for generic input. An empirical sweep (issue #54;
+500 iterations × 3 models × 8 solutions, seed 1337, 9148 valid samples) measured the
+rotation-invariant SO(3) geodesic distance between target and round-tripped orientation
+and found errors spanning the full `[0, π]` range with mean ≈1.52 rad (≈π/2, the
+statistical signature of two uncorrelated rotations) — confirming this is a genuine
+mismatch, not a bounded metric artifact. Per human ruling on #54 (2026-07), this is kept
+as documented v1.0 behavior for backward compatibility rather than fixed (fixing it
+would be an output-contract change requiring a golden re-baseline). Position remains a
+convention-independent invariant and continues to round-trip exactly. When comparing
+orientations, prefer a rotation-invariant metric (e.g. the SO(3) geodesic distance,
+`apps/demo/benchmarking.cpp`) over a raw per-component Euler diff.
 
 ## How it was generated
 

--- a/tests/test_golden_ik.cpp
+++ b/tests/test_golden_ik.cpp
@@ -6,7 +6,12 @@
 //   * NaN patterns match exactly (golden null <-> std::isnan),
 //   * round-trip: each NaN-free solution row, fed back through FK, reproduces the
 //     target *position* within kRoundTripPosTolerance (convention-independent
-//     invariant; Euler angles excluded per quirk Q5).
+//     invariant; Euler angles excluded per quirk Q5 -- a genuine FK-extract
+//     (ur_kinematics.h:46-49, R=RotY(e2)*RotZ(e1)*RotX(e0)) vs IK-compose
+//     (ur_kinematics.cpp:369-371, R=RotX(e0)*RotY(e1)*RotZ(e2)) convention asymmetry,
+//     not a two-fold Euler ambiguity -- confirmed by a rotation-invariant SO(3)
+//     geodesic sweep (issue #54; mean error ~1.52 rad across 9148 samples). Kept as
+//     documented v1.0 behavior per human ruling on #54; see tests/README.md.
 #include <gtest/gtest.h>
 
 #include <cmath>

--- a/tests/test_properties.cpp
+++ b/tests/test_properties.cpp
@@ -5,12 +5,14 @@
 // by design — only its properties are tested, not exact values).
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <numbers>
 #include <random>
 #include <utility>
 
+#include <Eigen/Dense>
 #include <ur_kinematics/ur_kinematics.h>
 #include "golden_config.hpp"
 
@@ -27,6 +29,26 @@ namespace
 													  universalRobots::rad(78), universalRobots::rad(66),
 													  universalRobots::rad(77), universalRobots::rad(12)};
 		return robot.forwardKinematics(joints);
+	}
+
+	// Reconstructs the rotation matrix implied by a pose's stored Euler triple, using
+	// the SAME convention forwardKinematics()'s FK-extract uses (the pose(pos,
+	// Eigen::Matrix3f) ctor: eulerAngles(1,2,0) remapped to {gamma,beta,alpha} order),
+	// which Eigen guarantees is an exact inverse of that extraction (see #54).
+	Eigen::Matrix3f reconstructRotation(const universalRobots::pose& p)
+	{
+		return Eigen::Matrix3f(Eigen::AngleAxisf(p.m_eulerAngles[2], Eigen::Vector3f::UnitY()) *
+								Eigen::AngleAxisf(p.m_eulerAngles[1], Eigen::Vector3f::UnitZ()) *
+								Eigen::AngleAxisf(p.m_eulerAngles[0], Eigen::Vector3f::UnitX()));
+	}
+
+	// Rotation-invariant SO(3) geodesic distance (radians); not sensitive to the
+	// two-fold Euler representation ambiguity, unlike a raw Euler-component diff.
+	float geodesicOrientationError(const universalRobots::pose& a, const universalRobots::pose& b)
+	{
+		const Eigen::Matrix3f relative = reconstructRotation(a).transpose() * reconstructRotation(b);
+		const float cosTheta = std::clamp((relative.trace() - 1.0f) / 2.0f, -1.0f, 1.0f);
+		return std::acos(cosTheta);
 	}
 } // namespace
 
@@ -64,6 +86,66 @@ TEST(Property, FkIkRoundTrip)
 	}
 	// Guards against a silent no-op regression (e.g. inverseKinematics always invalid).
 	EXPECT_GT(totalValidChecked, 0);
+}
+
+// ---- FK . IK orientation round trip: honestly does NOT hold (quirk Q5) ----
+//
+// #54 diagnosed (see docs/wiki + tests/README.md) that the FK-extract
+// (ur_kinematics.h pose(pos, Eigen::Matrix3f) ctor) and IK-compose
+// (ur_kinematics.cpp inverseKinematics()) use genuinely different Euler
+// composition conventions for the same stored (e0,e1,e2) triple -- FK-extract
+// implies R=RotY(e2)*RotZ(e1)*RotX(e0), IK-compose builds R=RotX(e0)*RotY(e1)*RotZ(e2).
+// These are not algebraic inverses, so IK(FK(q)) does not round-trip orientation, even
+// though it round-trips position (see FkIkRoundTrip above). This is a deliberate,
+// documented v1.0 behavior kept for backward compatibility (human ruling on #54:
+// Option A, non-breaking) -- NOT a bug this test should mask. We measure the
+// orientation gap with a rotation-invariant metric (SO(3) geodesic distance) so the
+// two-fold Euler representation ambiguity cannot produce a false pass or false fail,
+// and assert it is non-trivially large rather than asserting a brittle exact value.
+// A prior empirical sweep (500 iters x 3 models x 8 solutions, seed 1337) found a mean
+// geodesic error of ~1.52 rad (close to pi/2, consistent with the two conventions
+// producing effectively uncorrelated rotations for generic input).
+TEST(Property, FkIkOrientationDoesNotRoundTripQ5)
+{
+	std::mt19937 gen(kSeed);
+	std::uniform_real_distribution<float> dist(-std::numbers::pi_v<float>, std::numbers::pi_v<float>);
+
+	int totalValidChecked = 0;
+	double sumGeodesicError = 0.0;
+	for (const auto& model : goldencfg::models())
+	{
+		universalRobots::UR robot(model.type, false, 0.0f);
+		for (int iter = 0; iter < kRoundTripIterations; ++iter)
+		{
+			universalRobots::UR::JointVector joints{};
+			for (float& j : joints)
+				j = dist(gen);
+
+			const universalRobots::pose target = robot.forwardKinematics(joints);
+			const universalRobots::UR::IkSolutions sols = robot.inverseKinematics(target);
+
+			for (int s = 0; s < 8; ++s)
+			{
+				if (!sols.valid[s])
+					continue;
+				const universalRobots::pose fk = robot.forwardKinematics(sols.solutions[s]);
+				// Position still round-trips (convention-independent invariant).
+				for (int i = 0; i < 3; ++i)
+					EXPECT_NEAR(fk.m_pos[i], target.m_pos[i], goldencfg::kRoundTripPosTolerance)
+						<< model.name << " iter " << iter << " sol " << s << " pos[" << i << "]";
+				sumGeodesicError += geodesicOrientationError(target, fk);
+				++totalValidChecked;
+			}
+		}
+	}
+	ASSERT_GT(totalValidChecked, 0); // guards against a silent no-op regression
+	const double meanGeodesicError = sumGeodesicError / totalValidChecked;
+	// Soft lower bound, not a brittle exact value: comfortably below the ~1.52 rad
+	// mean observed empirically, but far above what a mere numerical-precision gap
+	// (which the FkIkRoundTrip position check already bounds at 1e-4) could produce.
+	// Documents quirk Q5 as current behavior; do NOT tighten this into an
+	// orientation-round-trips-exactly assertion (it doesn't, by design -- see above).
+	EXPECT_GT(meanGeodesicError, 0.1) << "expected orientation to NOT round-trip (quirk Q5)";
 }
 
 // ---- generateRandomReachablePose(): non-deterministic by design, properties only ----

--- a/tests/test_properties.cpp
+++ b/tests/test_properties.cpp
@@ -37,9 +37,10 @@ namespace
 	// which Eigen guarantees is an exact inverse of that extraction (see #54).
 	Eigen::Matrix3f reconstructRotation(const universalRobots::pose& p)
 	{
-		return Eigen::Matrix3f(Eigen::AngleAxisf(p.m_eulerAngles[2], Eigen::Vector3f::UnitY()) *
-								Eigen::AngleAxisf(p.m_eulerAngles[1], Eigen::Vector3f::UnitZ()) *
-								Eigen::AngleAxisf(p.m_eulerAngles[0], Eigen::Vector3f::UnitX()));
+		const Eigen::AngleAxisf rotY(p.m_eulerAngles[2], Eigen::Vector3f::UnitY());
+		const Eigen::AngleAxisf rotZ(p.m_eulerAngles[1], Eigen::Vector3f::UnitZ());
+		const Eigen::AngleAxisf rotX(p.m_eulerAngles[0], Eigen::Vector3f::UnitX());
+		return Eigen::Matrix3f(rotY * rotZ * rotX);
 	}
 
 	// Rotation-invariant SO(3) geodesic distance (radians); not sensitive to the


### PR DESCRIPTION
## Summary
- #54 diagnosed a **genuine FK-extract vs IK-compose Euler convention asymmetry** (not a two-fold Euler representation ambiguity): FK-extract (`ur_kinematics.h:46-49`) implies `R=RotY(e2)*RotZ(e1)*RotX(e0)`, IK-compose (`ur_kinematics.cpp:369-371`) builds `R=RotX(e0)*RotY(e1)*RotZ(e2)` from the same stored triple — confirmed by a rotation-invariant SO(3) geodesic sweep (9148 valid samples, mean ≈1.52 rad, spanning the full [0,π] range).
- Per human ruling (Option A): this stays as **documented v1.0 behavior for backward compatibility**, not a convention fix. This PR is **non-breaking**: no FK/IK arithmetic change, no golden data change, no public API change.
- Upgrades the demo benchmark's orientation metric to the rotation-invariant SO(3) geodesic distance (replacing a raw per-component Euler diff that is skewed by the asymmetry).
- Adds a property test that honestly characterizes current behavior (position round-trips exactly; orientation does not — quirk Q5), using the geodesic metric rather than a brittle magic-number assertion.
- Strengthens Q5 documentation (`tests/README.md`, `test_golden_ik.cpp`, `docs/wiki/UR-Class-API.md`, `docs/wiki/Kinematics-Theory.md`) with the precise root-cause sites and empirical evidence, and corrects the incorrect "single ZYX convention" claim in the wiki.

## Test plan
- [x] `ctest --test-dir build -C Release` — 53/53 passed (52 pre-existing + 1 new property test), golden suite bit-identical
- [x] `git diff --stat -- tests/golden/` — empty (golden untouched)
- [x] Manual `ur_demo` run — benchmark now prints `average orientation error, SO(3) geodesic distance (rad): ~1.5`, consistent with the #54 diagnostic
- [x] No public API/signature changes; no FK/IK arithmetic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Benchmarking**
  * Updated orientation accuracy reporting to use a rotation-invariant SO(3) angular (geodesic) error instead of averaged per-axis Euler differences.

* **Tests**
  * Expanded golden replay documentation to explicitly note the expected rotation-invariant behavior and preserved v1.0 semantics.
  * Added SO(3)-aware property coverage for the known FK/IK orientation non-round-trip case (Q5), while continuing to verify position round-tripping.

* **Documentation**
  * Clarified in the tolerances guidance why orientation isn’t an algebraic inverse, and documented the intentional behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->