### PR TITLE
feat: IK solution-selection helpers (joint-limit filter + nearest-to-current)

### DIFF
--- a/docs/wiki/UR-Class-API.md
+++ b/docs/wiki/UR-Class-API.md
@@ -57,6 +57,40 @@ Computes the tip `pose` for a given set of 6 joint angles (radians). Throws `std
 
 Computes all 8 geometric inverse-kinematics solutions for a target tip pose (position + Euler angles). See [Kinematics Theory](Kinematics-Theory) for how the 8 solutions correspond to shoulder-left/right, elbow-up/down, and wrist-up/down configurations.
 
+## Picking a solution: `JointLimits`, `filterByJointLimits`, `nearestSolution`
+
+`inverseKinematics()` returns up to 8 candidate solutions; `valid[i]` marks the geometrically feasible ones, but a geometrically feasible row can still hold a joint angle outside the range `forwardKinematics()` accepts (`[-2π, 2π]`), which would make feeding it back into `forwardKinematics()` throw. These free functions close that gap and help pick one solution to drive the robot with:
+
+```cpp
+struct JointLimits
+{
+    JointVector lower;
+    JointVector upper;
+};
+
+inline constexpr JointLimits kDefaultUrLimits; // [-2π, +2π] per joint, matching forwardKinematics()'s range exactly
+
+void filterByJointLimits(UR::IkSolutions& solutions, const JointLimits& limits = kDefaultUrLimits);
+
+[[nodiscard]] std::optional<std::size_t> nearestSolution(const UR::IkSolutions& solutions,
+                                                           const JointVector& current);
+```
+
+- `filterByJointLimits` marks `valid[i] = false` for any row with a joint outside `limits` (inclusive bounds); it only prunes — it never marks an already-invalid row valid, and never reorders rows. With the default limits, any solution that survives is guaranteed to be accepted by `forwardKinematics()`.
+- `nearestSolution` returns the index of the valid row closest to `current` (summed per-joint `|Δ|`, no angle-wraparound handling), or `std::nullopt` if none are valid.
+
+```cpp
+universalRobots::UR robot(universalRobots::URtype::UR5);
+universalRobots::UR::IkSolutions sols = robot.inverseKinematics(targetPose);
+
+universalRobots::filterByJointLimits(sols); // prune anything forwardKinematics() would reject
+
+if (auto idx = universalRobots::nearestSolution(sols, currentJointVector))
+{
+    const universalRobots::pose reached = robot.forwardKinematics(sols.solutions[*idx]); // never throws here
+}
+```
+
 ## `isPoseReachable`
 
 ```cpp

--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -5,6 +5,9 @@
 #include <iosfwd>
 #include <array>
 #include <algorithm>
+#include <cstddef>
+#include <numbers>
+#include <optional>
 #include <type_traits>
 #include <Eigen/Dense>
 #include "robot_parameters.h"
@@ -254,5 +257,49 @@ namespace universalRobots
 	std::ostream& operator<<(std::ostream& stream, universalRobots::URtype type);
 
 	std::ostream& operator<<(std::ostream& stream, const universalRobots::UR& robot);
+
+	/** @brief Per-joint inclusive [lower, upper] bounds (radians) used by filterByJointLimits(). */
+	struct JointLimits
+	{
+		UR::JointVector lower;
+		UR::JointVector upper;
+	};
+
+	namespace detail
+	{
+		constexpr JointLimits makeDefaultUrLimits()
+		{
+			constexpr float kTwoPi = 2.0f * std::numbers::pi_v<float>;
+			JointLimits limits{};
+			for (std::size_t i = 0; i < UR::m_numDoF; ++i)
+			{
+				limits.lower[i] = -kTwoPi;
+				limits.upper[i] = kTwoPi;
+			}
+			return limits;
+		}
+	} // namespace detail
+
+	/**
+	 * @brief Default joint limits: [-2π, +2π] per joint, matching forwardKinematics()'s
+	 * accepted range exactly (see forwardKinematics()'s precondition) -- a solution that
+	 * survives filterByJointLimits(kDefaultUrLimits) is guaranteed FK-consumable.
+	 */
+	inline constexpr JointLimits kDefaultUrLimits = detail::makeDefaultUrLimits();
+
+	/**
+	 * @brief Marks solutions.valid[i] false where any joint of solutions.solutions[i] falls
+	 * outside [limits.lower[j], limits.upper[j]]. Prune-only: never flips an already-false
+	 * row to true, and never reorders or renumbers rows. Bounds are inclusive.
+	 */
+	void filterByJointLimits(UR::IkSolutions& solutions, const JointLimits& limits = kDefaultUrLimits);
+
+	/**
+	 * @brief Index of the valid row in `solutions` nearest to `current`, by summed
+	 * per-joint |Δ| (plain minimal-travel metric, no angle-wraparound handling).
+	 * Returns std::nullopt when no row is valid.
+	 */
+	[[nodiscard]] std::optional<std::size_t> nearestSolution(const UR::IkSolutions& solutions,
+															 const UR::JointVector& current);
 
 } // namespace universalRobots

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -542,7 +542,7 @@ namespace universalRobots
 			float distance = 0.0f;
 			for (unsigned int j = 0; j < UR::m_numDoF; ++j)
 				distance += std::abs(solutions.solutions[i][j] - current[j]);
-			if (!best.has_value() || distance < bestDistance)
+			if (distance < bestDistance)
 			{
 				best = i;
 				bestDistance = distance;

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -501,6 +501,57 @@ namespace universalRobots
 	}
 
 	/// <summary>
+	/// Marks solutions.valid[i] false where any joint of solutions.solutions[i] falls outside
+	/// [limits.lower[j], limits.upper[j]]. Prune-only: never flips an already-false row to
+	/// true, never reorders rows.
+	/// </summary>
+	/// <param name="solutions"></param>
+	/// <param name="limits"></param>
+	void filterByJointLimits(UR::IkSolutions& solutions, const JointLimits& limits)
+	{
+		for (unsigned int i = 0; i < UR::m_numIkSol; ++i)
+		{
+			if (!solutions.valid[i])
+				continue;
+			for (unsigned int j = 0; j < UR::m_numDoF; ++j)
+			{
+				const float angle = solutions.solutions[i][j];
+				if (angle < limits.lower[j] || angle > limits.upper[j])
+				{
+					solutions.valid[i] = false;
+					break;
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// Index of the valid row in `solutions` nearest to `current`, by summed per-joint
+	/// |delta|. Returns std::nullopt when no row is valid.
+	/// </summary>
+	/// <param name="solutions"></param>
+	/// <param name="current"></param>
+	std::optional<std::size_t> nearestSolution(const UR::IkSolutions& solutions, const UR::JointVector& current)
+	{
+		std::optional<std::size_t> best;
+		float bestDistance = std::numeric_limits<float>::max();
+		for (std::size_t i = 0; i < UR::m_numIkSol; ++i)
+		{
+			if (!solutions.valid[i])
+				continue;
+			float distance = 0.0f;
+			for (unsigned int j = 0; j < UR::m_numDoF; ++j)
+				distance += std::abs(solutions.solutions[i][j] - current[j]);
+			if (!best.has_value() || distance < bestDistance)
+			{
+				best = i;
+				bestDistance = distance;
+			}
+		}
+		return best;
+	}
+
+	/// <summary>
 	/// Operator overloading to be able to print a URtype enum.
 	/// </summary>
 	/// <param name="stream"></param>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(ur_kinematics_tests
     test_robot_parameters.cpp
     test_pose_and_fk_anchors.cpp
     test_properties.cpp
+    test_ik_selection.cpp
 )
 target_include_directories(ur_kinematics_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 # test_math_utils.cpp unit-tests calcTransformationMatrix directly, which is a

--- a/tests/test_ik_selection.cpp
+++ b/tests/test_ik_selection.cpp
@@ -1,0 +1,179 @@
+// test_ik_selection.cpp — task 64: IK solution-selection helpers (joint-limit
+// filter + nearest-to-current pick).
+//
+// All tests use a seeded std::mt19937 for determinism.
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <numbers>
+#include <random>
+#include <stdexcept>
+
+#include <ur_kinematics/ur_kinematics.h>
+#include "golden_config.hpp"
+
+namespace
+{
+	constexpr int kSeed = 6464;				  // distinct from other test files' seeds
+	constexpr int kSweepIterationsPerModel = 300;
+
+	universalRobots::UR::IkSolutions makeAllInvalid()
+	{
+		universalRobots::UR::IkSolutions sols{};
+		sols.valid.fill(false);
+		return sols;
+	}
+} // namespace
+
+// ---- filterByJointLimits(): prune-only, never reorders, never un-invalidates ----
+
+TEST(IkSelection, FilterMarksOutOfRangeInvalid)
+{
+	universalRobots::UR::IkSolutions sols{};
+	sols.valid.fill(true);
+	sols.solutions[0] = {0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f};	// within the tight limit below
+	sols.solutions[1] = {0.1f, 0.1f, 0.1f, 5.0f, 0.1f, 0.1f}; // joint 3 exceeds it
+
+	universalRobots::JointLimits tight{};
+	tight.lower.fill(-1.0f);
+	tight.upper.fill(1.0f);
+
+	universalRobots::filterByJointLimits(sols, tight);
+
+	EXPECT_TRUE(sols.valid[0]);
+	EXPECT_FALSE(sols.valid[1]);
+	for (std::size_t i = 2; i < universalRobots::UR::m_numIkSol; ++i)
+		EXPECT_TRUE(sols.valid[i]) << i; // default-constructed {0,...} is within the tight limit
+}
+
+TEST(IkSelection, FilterNeverFlipsAlreadyInvalidToValid)
+{
+	universalRobots::UR::IkSolutions sols = makeAllInvalid();
+	sols.solutions[3] = {0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f}; // in-range, but valid[3] starts false
+
+	universalRobots::filterByJointLimits(sols); // default limits
+
+	for (bool v : sols.valid)
+		EXPECT_FALSE(v);
+}
+
+TEST(IkSelection, FilterDoesNotReorderRows)
+{
+	universalRobots::UR::IkSolutions sols{};
+	sols.valid.fill(true);
+	for (unsigned int i = 0; i < universalRobots::UR::m_numIkSol; ++i)
+		sols.solutions[i].fill(static_cast<float>(i) * 0.01f);
+
+	const auto before = sols.solutions;
+	universalRobots::filterByJointLimits(sols); // default limits, nothing out of range
+	EXPECT_EQ(sols.solutions, before);
+}
+
+TEST(IkSelection, FilterDefaultAcceptsBoundaryValues)
+{
+	// forwardKinematics() rejects strictly j < -2pi or j > 2pi (src/ur_kinematics.cpp), so
+	// +-2pi itself must survive the default filter.
+	universalRobots::UR::IkSolutions sols{};
+	sols.valid.fill(true);
+	constexpr float kTwoPi = 2.0f * std::numbers::pi_v<float>;
+	sols.solutions[0].fill(kTwoPi);
+	sols.solutions[1].fill(-kTwoPi);
+
+	universalRobots::filterByJointLimits(sols);
+
+	EXPECT_TRUE(sols.valid[0]);
+	EXPECT_TRUE(sols.valid[1]);
+}
+
+TEST(IkSelection, FilterExcludesAnglesForwardKinematicsWouldReject)
+{
+	universalRobots::UR::IkSolutions sols{};
+	sols.valid.fill(true);
+	constexpr float kTwoPi = 2.0f * std::numbers::pi_v<float>;
+	sols.solutions[4].fill(kTwoPi + 0.01f); // just outside FK's accepted range
+
+	universalRobots::UR robot(universalRobots::URtype::UR5);
+	EXPECT_THROW({ (void)robot.forwardKinematics(sols.solutions[4]); }, std::invalid_argument);
+
+	universalRobots::filterByJointLimits(sols);
+	EXPECT_FALSE(sols.valid[4]);
+}
+
+// ---- nearestSolution(): least-travel pick among valid rows ----
+
+TEST(IkSelection, NearestSolutionPicksLeastTravel)
+{
+	universalRobots::UR::IkSolutions sols{};
+	sols.valid.fill(false);
+	sols.valid[1] = true;
+	sols.valid[5] = true;
+	sols.solutions[1].fill(1.0f);
+	sols.solutions[5].fill(0.2f);
+
+	const universalRobots::UR::JointVector current{}; // all zero
+
+	const auto result = universalRobots::nearestSolution(sols, current);
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(*result, 5u);
+}
+
+TEST(IkSelection, NearestSolutionReturnsNulloptWhenNoneValid)
+{
+	const universalRobots::UR::IkSolutions sols = makeAllInvalid();
+	const universalRobots::UR::JointVector current{};
+	EXPECT_FALSE(universalRobots::nearestSolution(sols, current).has_value());
+}
+
+TEST(IkSelection, NearestSolutionIgnoresInvalidRowsEvenIfCloser)
+{
+	universalRobots::UR::IkSolutions sols{};
+	sols.valid.fill(false);
+	sols.valid[6] = true;
+	sols.solutions[2].fill(0.001f); // closer to `current`, but invalid
+	sols.solutions[6].fill(2.0f);
+
+	const universalRobots::UR::JointVector current{};
+	const auto result = universalRobots::nearestSolution(sols, current);
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(*result, 6u);
+}
+
+// ---- FK-consumable guarantee: the headline correctness proof for #64 ----
+//
+// forwardKinematics() throws std::invalid_argument for any joint outside [-2pi, +2pi]
+// (src/ur_kinematics.cpp). kDefaultUrLimits is defined to match that range exactly, so
+// every solution surviving filterByJointLimits(default) is FK-consumable by
+// construction; this test proves that holds across a sweep of reachable target poses,
+// not just by the limits' definitional equality.
+TEST(IkSelection, DefaultFilterSurvivorsAreAlwaysFkConsumable)
+{
+	std::mt19937 gen(kSeed);
+	std::uniform_real_distribution<float> dist(-std::numbers::pi_v<float>, std::numbers::pi_v<float>);
+
+	int totalChecked = 0;
+	for (const auto& model : goldencfg::models())
+	{
+		universalRobots::UR robot(model.type, false, 0.0f);
+		for (int iter = 0; iter < kSweepIterationsPerModel; ++iter)
+		{
+			universalRobots::UR::JointVector joints{};
+			for (float& j : joints)
+				j = dist(gen);
+
+			const universalRobots::pose target = robot.forwardKinematics(joints);
+			universalRobots::UR::IkSolutions sols = robot.inverseKinematics(target);
+			universalRobots::filterByJointLimits(sols);
+
+			for (unsigned int s = 0; s < universalRobots::UR::m_numIkSol; ++s)
+			{
+				if (!sols.valid[s])
+					continue;
+				EXPECT_NO_THROW({ (void)robot.forwardKinematics(sols.solutions[s]); })
+					<< model.name << " iter " << iter << " sol " << s;
+				++totalChecked;
+			}
+		}
+	}
+	EXPECT_GT(totalChecked, 0); // guards against a silent no-op regression
+}

--- a/tests/test_ik_selection.cpp
+++ b/tests/test_ik_selection.cpp
@@ -15,7 +15,7 @@
 
 namespace
 {
-	constexpr int kSeed = 6464;				  // distinct from other test files' seeds
+	constexpr int kSeed = 6464; // distinct from other test files' seeds
 	constexpr int kSweepIterationsPerModel = 300;
 
 	universalRobots::UR::IkSolutions makeAllInvalid()
@@ -32,7 +32,7 @@ TEST(IkSelection, FilterMarksOutOfRangeInvalid)
 {
 	universalRobots::UR::IkSolutions sols{};
 	sols.valid.fill(true);
-	sols.solutions[0] = {0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f};	// within the tight limit below
+	sols.solutions[0] = {0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f}; // within the tight limit below
 	sols.solutions[1] = {0.1f, 0.1f, 0.1f, 5.0f, 0.1f, 0.1f}; // joint 3 exceeds it
 
 	universalRobots::JointLimits tight{};


### PR DESCRIPTION
## Summary
Closes #64 — adds IK solution-selection helpers so a caller can go from `inverseKinematics()`'s 8 candidate solutions to one FK-consumable solution to drive the robot with.

- **`JointLimits`** struct (`lower`/`upper` `JointVector`) + **`kDefaultUrLimits`** = `[-2π, +2π]` per joint, matching `forwardKinematics()`'s accepted range exactly (`src/ur_kinematics.cpp` `forwardKinematics()` precondition).
- **`filterByJointLimits(IkSolutions&, limits = kDefaultUrLimits)`** — marks `valid[i] = false` for any row with a joint outside `limits` (inclusive bounds). Prune-only: never flips an already-invalid row to valid, never reorders rows. With the default limits, any surviving solution is guaranteed accepted by `forwardKinematics()` — this closes the sharp edge where a geometrically-valid IK row could still hold an angle outside `[-2π, 2π]` and make `forwardKinematics()` throw.
- **`nearestSolution(const IkSolutions&, const JointVector& current) -> std::optional<std::size_t>`** — index of the valid solution minimizing summed per-joint `|Δ|` travel from `current`; `std::nullopt` if none valid. Plain minimal-travel metric, no angle-wraparound handling (UR joints already live in `[-2π, 2π]`).
- New test file `tests/test_ik_selection.cpp`: unit tests for filter (marks out-of-range invalid, overridable limits, never un-invalidates, no reordering, boundary values accepted, excludes angles FK would reject) and `nearestSolution` (least-travel pick, `nullopt` when none valid, ignores invalid rows), plus the headline **FK-consumable guarantee test** — sweeps reachable target poses across all 3 models (seeded RNG) and asserts every solution surviving `filterByJointLimits(default)` is accepted by `forwardKinematics()` without throwing.
- Wiki example added to `docs/wiki/UR-Class-API.md` (filter → `nearestSolution` → drive FK).

This is a formal, purely **additive** public API change (ABI-additive) — no existing signatures, FK/IK arithmetic, or `operator<<` output changed.

## Test plan
- [x] `cmake --build build --config Release -j` — clean build
- [x] `ctest --test-dir build -C Release --output-on-failure` — 62/62 passing (53 pre-existing + 9 new)
- [x] `git diff --stat main -- tests/golden/` — empty (golden data untouched)
- [x] No changes to `src/ur_kinematics.cpp`'s existing FK/IK arithmetic or `include/ur_kinematics/ur_kinematics.h`'s existing public signatures — only new declarations/definitions added
- [x] Wiki doc updated with a worked example

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering inverse-kinematics solutions by configurable per-joint limits.
  * Added nearest-solution selection based on minimum joint movement.
  * Added default limits of ±2π radians for all six joints.
  * Invalid or unavailable solutions are handled safely without changing solution order.

* **Tests**
  * Added comprehensive coverage for joint-limit filtering and nearest-solution selection across supported robot models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->