### PR TITLE
feat: continuous-radian sampling for generateRandomReachablePose (closes #65)

### DIFF
--- a/docs/wiki/UR-Class-API.md
+++ b/docs/wiki/UR-Class-API.md
@@ -103,11 +103,14 @@ Equivalent to `inverseKinematics(targetPose).anyValid()` — use this when you o
 
 ```cpp
 pose generateRandomReachablePose();
+pose generateRandomReachablePose(unsigned int seed);
 ```
 
 Picks random joint angles within the robots' limits and runs forward kinematics, returning a pose that is reachable by construction. Useful for tests and benchmarking (see [Benchmarking](Benchmarking)).
 
-Note that "reachable by construction" means the arm can physically get there — the pose is the forward-kinematics image of a real, in-limits joint configuration. It does **not** mean this library's analytic inverse-kinematics solver can necessarily recover a solution for it. A joint draw that swings the wrist center close to the base's vertical axis can land it inside a small cylindrical region around that axis that the solver's closed-form math cannot invert, so `isPoseReachable()` (and `inverseKinematics()`) may reject a fraction of the poses this function generates. In practice this affects roughly a fifth of draws across the full ±360° joint range (e.g. around 159/200 in a seeded UR3 run). If your use case needs every generated pose to be solvable, check `isPoseReachable()` on the result and redraw as needed.
+Joint angles are drawn continuously (`std::uniform_real_distribution<float>`) from `forwardKinematics()`'s full accepted range, `[-2π, +2π]` radians per joint — not a fixed integer-degree grid. The no-arg overload seeds from `std::random_device`; the seeded overload samples deterministically from a caller-supplied seed, for reproducible tests.
+
+Note that "reachable by construction" means the arm can physically get there — the pose is the forward-kinematics image of a real, in-limits joint configuration. It does **not** mean this library's analytic inverse-kinematics solver can necessarily recover a solution for it. A joint draw that swings the wrist center close to the base's vertical axis can land it inside a small cylindrical region around that axis that the solver's closed-form math cannot invert, so `isPoseReachable()` (and `inverseKinematics()`) may reject a fraction of the poses this function generates. In practice this affects roughly a fifth of draws across the full ±2π joint range (e.g. around 159/200 in a seeded UR3 run). If your use case needs every generated pose to be solvable, check `isPoseReachable()` on the result and redraw as needed.
 
 ## `isSolutionValid` (static)
 

--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -192,6 +192,8 @@ namespace universalRobots
 		/// Returns true iff inverseKinematics(targetPose).anyValid().
 		[[nodiscard]] bool isPoseReachable(const pose& targetPose) const;
 		pose generateRandomReachablePose() const;
+		/// Deterministic overload: samples with a caller-supplied seed instead of std::random_device.
+		pose generateRandomReachablePose(unsigned int seed) const;
 		[[nodiscard]] static bool isSolutionValid(const std::array<float, m_numDoF>& ikSolution);
 		friend std::ostream& operator<<(std::ostream& stream, const universalRobots::UR& robot);
 		friend std::ostream& operator<<(std::ostream& stream, universalRobots::URtype type);

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -35,6 +35,10 @@ namespace
 	// (theta1_phi, theta5, theta3_psi): clamp when |arg| in (1, 1+eps]; invalid beyond.
 	constexpr float kAcosEps = 1e-6f;
 
+	// forwardKinematics()'s accepted joint range is [-kTwoPi, +kTwoPi]; shared here so
+	// generateRandomReachablePose() can sample within it without redefining it.
+	constexpr float kTwoPi = 2.0f * std::numbers::pi_v<float>;
+
 	// Streams a frame's transform-label number (e.g. "4" or, for the primed
 	// intermediate wrist frames not in kPoseBearingFrames, "4'"). The number is
 	// the count of pose-bearing frames up to and including this one, so the
@@ -148,7 +152,6 @@ namespace universalRobots
 	/// <returns>tipPose</returns>
 	pose UR::forwardKinematics(const JointVector& targetJointVal) const
 	{
-		constexpr float kTwoPi = 2.0f * std::numbers::pi_v<float>;
 		for (unsigned int i = 0; i < m_numDoF; ++i)
 		{
 			const float j = targetJointVal[i];
@@ -469,16 +472,29 @@ namespace universalRobots
 	/// <returns>randomValidTargetPose</returns>
 	pose UR::generateRandomReachablePose() const
 	{
-		//// https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution
 		std::random_device rd;
-		std::mt19937 gen(rd());
-		std::uniform_int_distribution<> distrib(-360, 360); // URs joints limits [-360; 360]
+		return generateRandomReachablePose(rd());
+	}
+
+	/// <summary>
+	/// Generates a valid tip pose by running forward kinematics with random target joint values,
+	/// sampled deterministically from the given seed.
+	/// </summary>
+	/// <param name="seed"></param>
+	/// <returns>randomValidTargetPose</returns>
+	pose UR::generateRandomReachablePose(unsigned int seed) const
+	{
+		std::mt19937 gen(seed);
+		// Upper bound is nextafter(kTwoPi, 0.0f): defensive against uniform_real_distribution's
+		// known float-rounding-to-upper-bound quirk, so every draw stays within
+		// forwardKinematics()'s accepted [-kTwoPi, +kTwoPi] range.
+		std::uniform_real_distribution<float> distrib(-kTwoPi, std::nextafter(kTwoPi, 0.0f));
 
 		JointVector randomTargetJointValue = {};
 
 		for (unsigned int i = 0; i < m_numDoF; i++)
 		{
-			randomTargetJointValue[i] = universalRobots::rad(static_cast<float>(distrib(gen)));
+			randomTargetJointValue[i] = distrib(gen);
 		}
 
 		return forwardKinematics(randomTargetJointValue);

--- a/tests/test_properties.cpp
+++ b/tests/test_properties.cpp
@@ -2,7 +2,8 @@
 //
 // All property tests use a seeded std::mt19937 (deterministic, fixed across runs);
 // generateRandomReachablePose() is the one documented exception (uses random_device
-// by design — only its properties are tested, not exact values).
+// by design — only its properties are tested, not exact values). Its seeded overload
+// (generateRandomReachablePose(unsigned int)) is used where determinism is needed.
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -193,6 +194,71 @@ TEST(Property, GenerateRandomReachablePoseRepeatedCallsDiffer)
 			anyDiffers = true;
 	}
 	EXPECT_TRUE(anyDiffers) << "two consecutive draws produced an identical pose";
+}
+
+// ---- generateRandomReachablePose(seed): task 65's continuous-radian sampling ----
+//
+// forwardKinematics() throws for any joint outside [-2pi, +2pi] (src/ur_kinematics.cpp);
+// the seeded overload samples with std::uniform_real_distribution<float> over exactly
+// that range, so every draw is FK-consumable by construction. Swept here across many
+// draws x 3 models as the same kind of empirical proof #64's FK-consumable test used.
+TEST(Property, GenerateRandomReachablePoseSeededNeverThrows)
+{
+	constexpr int kDraws = 200;
+	for (const auto& model : goldencfg::models())
+	{
+		universalRobots::UR robot(model.type);
+		for (int i = 0; i < kDraws; ++i)
+			EXPECT_NO_THROW({ (void)robot.generateRandomReachablePose(static_cast<unsigned int>(kSeed + i)); })
+				<< model.name << " draw " << i;
+	}
+}
+
+TEST(Property, GenerateRandomReachablePoseSeededIsDeterministic)
+{
+	universalRobots::UR robot(universalRobots::URtype::UR5);
+	const universalRobots::pose a = robot.generateRandomReachablePose(4242u);
+	const universalRobots::pose b = robot.generateRandomReachablePose(4242u);
+	EXPECT_EQ(a.m_pos, b.m_pos);
+	EXPECT_EQ(a.m_eulerAngles, b.m_eulerAngles);
+}
+
+// The old implementation sampled whole degrees (std::uniform_int_distribution then
+// rad(static_cast<float>(...))), so the original joint value was always an exact
+// multiple of 1 degree. The new std::uniform_real_distribution<float> samples
+// continuously in radians. Recovering a draw's joints via inverseKinematics() and
+// checking against the nearest degree grid point distinguishes the two: with genuinely
+// continuous sampling, landing exactly on a degree multiple has probability ~0.
+TEST(Property, GenerateRandomReachablePoseSamplesContinuousRadians)
+{
+	constexpr int kDraws = 40;
+	constexpr float kDegPerRad = 180.0f / std::numbers::pi_v<float>;
+	constexpr float kGridEps = 0.01f; // degrees; well above float noise, well below a real grid step
+	bool sawOffGrid = false;
+	for (const auto& model : goldencfg::models())
+	{
+		universalRobots::UR robot(model.type);
+		for (int i = 0; i < kDraws && !sawOffGrid; ++i)
+		{
+			const universalRobots::pose p = robot.generateRandomReachablePose(static_cast<unsigned int>(kSeed + i));
+			const universalRobots::UR::IkSolutions sols = robot.inverseKinematics(p);
+			for (unsigned int s = 0; s < universalRobots::UR::m_numIkSol && !sawOffGrid; ++s)
+			{
+				if (!sols.valid[s])
+					continue;
+				for (float j : sols.solutions[s])
+				{
+					const float deg = j * kDegPerRad;
+					if (std::abs(deg - std::round(deg)) > kGridEps)
+					{
+						sawOffGrid = true;
+						break;
+					}
+				}
+			}
+		}
+	}
+	EXPECT_TRUE(sawOffGrid) << "expected at least one recovered joint value at sub-degree resolution";
 }
 
 // ---- IK solution-family structure (BASELINE.md index semantics) ----


### PR DESCRIPTION
## Summary
- `generateRandomReachablePose()` sampled joints from a fixed 721-value integer-degree grid (`std::uniform_int_distribution<>(-360,360)` + `rad()`). Replaced with `std::uniform_real_distribution<float>` sampling directly in radians over `forwardKinematics()`'s full accepted range `[-2pi, +2pi]` (upper bound `std::nextafter(kTwoPi, 0.0f)`, defensive against the distribution's known float-rounding-to-upper-bound quirk). Every draw is FK-consumable by construction.
- Hoisted the previously function-local `kTwoPi` in `forwardKinematics()` into the translation unit's anonymous namespace so it's shared, not redefined.
- Added an additive seeded overload `generateRandomReachablePose(unsigned int seed)` for deterministic tests; the existing no-arg overload now delegates to it via `std::random_device`, so its non-deterministic behavior is unchanged.
- Updated `docs/wiki/UR-Class-API.md` for the new sampling range and the seeded overload.

## Test plan
- [x] New property tests in `tests/test_properties.cpp`: seeded draws never throw (200 draws x UR3/5/10), the seeded overload is deterministic (same seed -> same pose), and recovered joint values land at sub-degree resolution (proves continuous sampling vs. the old integer-degree grid).
- [x] Full local suite: 65/65 green.
- [x] `git diff --stat -- tests/golden/` empty throughout — RNG-based, not golden-compared.
- [x] No existing public signatures changed (additive seeded overload only); `operator<<` untouched; all-float, no double/auto promotion.

Closes #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional seed when generating random reachable poses, enabling repeatable results for the same seed.
  - Random pose generation now samples joint values continuously in radians for more natural variation.

- **Improvements**
  - Updated pose generation behavior while preserving the existing no-argument option.
  - Enhanced reliability across reachable-pose generation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->