### PR TITLE
feat: geometric Jacobian + Yoshikawa manipulability (#63)

### DIFF
--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -8,6 +8,7 @@ A C++20 library for forward and inverse kinematics of Universal Robots (UR3/UR5/
 - **[UR Class API](UR-Class-API)** — constructor, `forwardKinematics()`, `inverseKinematics()`, and the other public members.
 - **[Modified Denavit-Hartenberg Convention](Modified-Denavit-Hartenberg-Convention)** — the 9-frame MDH parameterisation this library uses.
 - **[Kinematics Theory](Kinematics-Theory)** — how forward and inverse kinematics are derived and solved.
+- **[Jacobian Theory](Jacobian-Theory)** — the geometric (spatial) Jacobian, manipulability, and the three UR singularity families.
 - **[Benchmarking](Benchmarking)** — how to reproduce the timing and accuracy results.
 - **[CoppeliaSim Integration](CoppeliaSim-Integration)** — where the CoppeliaSim scenes and remote-API integration now live.
 

--- a/docs/wiki/Jacobian-Theory.md
+++ b/docs/wiki/Jacobian-Theory.md
@@ -6,7 +6,7 @@ This page summarises how `jacobian()` and `manipulability()` work: the geometric
 
 For a 6-DoF manipulator, the Jacobian `J(q)` (6×6, one column per joint) relates joint velocities to the tip's **spatial twist** — its instantaneous linear and angular velocity, stacked as a single 6-vector:
 
-```
+```text
 x_dot = J(q) * q_dot,   x_dot = [v; omega]  (v: linear, meters/s; omega: angular, rad/s)
 ```
 
@@ -21,7 +21,7 @@ All 6 UR joints are revolute. For a serial chain of revolute joints, column `i` 
 
 and the column is:
 
-```
+```text
 J_linear[i]  = z_i x (p_end - p_i)   (top 3 rows)
 J_angular[i] = z_i                    (bottom 3 rows)
 ```
@@ -49,11 +49,11 @@ The subtlety is *which* frame's z-axis/origin to use for `z_i`/`p_i`. Textbook d
 
 The Yoshikawa manipulability index measures how far a configuration `q` is from a singularity — a configuration where `J(q)` loses rank and some tip velocity directions become unreachable no matter how fast the joints move:
 
-```
+```text
 w(q) = sqrt(det(J(q) * J(q)^T))
 ```
 
-`J*J^T` is symmetric positive semi-definite by construction, so its determinant is mathematically never negative — but computed in `float`, right at or past a singularity the determinant can land a hair below zero from rounding alone. `manipulability()` clamps the radicand at 0 before the square root, so the result is always a finite, non-negative `float` (never `NaN`) — `0.0f` at a singularity rather than an ill-defined negative-root result.
+For this library's Jacobian, which is always square (6x6, one column per joint, no redundancy), `det(J * J^T) = det(J)^2`, so `sqrt(det(J * J^T)) == abs(det(J))`. `manipulability()` computes it that way — `abs(J(q).determinant())` — which is both faster (no 6x6 matrix product) and sidesteps the float-noise-negative-radicand problem a literal `sqrt(det(J*J^T))` would have right at a singularity, rather than computing then clamping it: `abs()` of a finite `float` is always finite and non-negative, so the result is never `NaN` and is `0.0f` (or vanishingly close) exactly at a singularity.
 
 `w(q)` is a single scalar summary; the **smallest singular value** of `J(q)` (e.g. via `Eigen::JacobiSVD`) is a related, more granular measure of the same thing — it goes to 0 exactly where `w(q)` does, but also identifies *which* direction in velocity space is becoming unreachable (the corresponding right-singular vector), which `w(q)` alone does not.
 

--- a/docs/wiki/Jacobian-Theory.md
+++ b/docs/wiki/Jacobian-Theory.md
@@ -1,0 +1,83 @@
+# Jacobian Theory
+
+This page summarises how `jacobian()` and `manipulability()` work: the geometric (spatial) manipulator Jacobian, its relation to the [MDH](Modified-Denavit-Hartenberg-Convention) frames this library already builds during forward kinematics, and manipulability as a measure of distance to a singularity.
+
+## Definition
+
+For a 6-DoF manipulator, the Jacobian `J(q)` (6×6, one column per joint) relates joint velocities to the tip's **spatial twist** — its instantaneous linear and angular velocity, stacked as a single 6-vector:
+
+```
+x_dot = J(q) * q_dot,   x_dot = [v; omega]  (v: linear, meters/s; omega: angular, rad/s)
+```
+
+`v` and `omega` here are the tip's linear and angular velocity expressed in the **base** frame — not, in general, the time-derivative of the stored `pose::m_eulerAngles` triple (see [Analytical vs. geometric Jacobian](#analytical-vs-geometric-jacobian-why-geometric) below for why that distinction matters for this library specifically).
+
+## Geometric Jacobian for revolute joints
+
+All 6 UR joints are revolute. For a serial chain of revolute joints, column `i` (0-based, joint `i+1`) of the geometric Jacobian is built from two quantities, both expressed in the base frame:
+
+- `z_i` — the unit vector along joint `i+1`'s rotation axis.
+- `p_i` — the origin of the frame joint `i+1` rotates.
+
+and the column is:
+
+```
+J_linear[i]  = z_i x (p_end - p_i)   (top 3 rows)
+J_angular[i] = z_i                    (bottom 3 rows)
+```
+
+`p_end` is the tip origin (`_0T_7`'s translation). The linear part is the classic "velocity of a point rigidly attached to a rotating frame" cross product: rotating joint `i+1` at unit rate sweeps every point rigidly downstream of it — including the tip — around the `z_i` axis through `p_i`, and a point at `p_end` moves at `z_i x (p_end - p_i)`. The angular part is simpler: rotating joint `i+1` alone contributes exactly its own axis to the tip's total angular velocity (angular velocities of a serial chain simply sum).
+
+### Mapping columns to this library's DH frames
+
+`forwardKinematics()` already builds `_0T_i` for all 9 [MDH frames](Modified-Denavit-Hartenberg-Convention) and caches them in `m_generalTransformationMatrices`; `jacobian()` reuses that cache directly rather than rebuilding any transforms.
+
+The subtlety is *which* frame's z-axis/origin to use for `z_i`/`p_i`. Textbook derivations usually index by "the frame **before** joint `i+1`'s own rotation is applied" (frequently written `z_{i-1}`, `p_{i-1}`), because in general a joint's rotation changes the frame's origin and z-axis for the *next* joint's transform. But there's a simplification specific to how each joint enters this library's per-row transform (`Rot_x(alpha) * Trans_x(a) * Trans_z(d) * Rot_z(theta_i)`, see [MDH Convention](Modified-Denavit-Hartenberg-Convention)): `Rot_z(theta_i)` is the *last* factor, and a rotation about z leaves both the z-axis and the origin unchanged. So the frame produced by *including* joint `i+1`'s own rotation has exactly the same z-axis and origin as the frame just before that rotation — meaning `z_i`/`p_i` can be read directly off the pose-bearing frame that joint `i+1` actuates, with no extra bookkeeping:
+
+| Joint | Column | Frame (`m_generalTransformationMatrices` index) |
+|---|---|---|
+| 1 | 0 | 0 (`_0T_1`) |
+| 2 | 1 | 1 (`_0T_2`) |
+| 3 | 2 | 2 (`_0T_3`) |
+| 4 | 3 | 3 (`_0T_4`) |
+| 5 | 4 | 5 (`_0T_5`, skipping intermediate frame 4 = `_0T_4'`) |
+| 6 | 5 | 7 (`_0T_6`, skipping intermediate frame 6 = `_0T_5'`) |
+
+`p_end` is frame 8 (`_0T_7`, the tip). Frames 4 and 6 are the fixed, non-joint-bearing half-frames the wrist needs (see the MDH page); they never supply a Jacobian column.
+
+## Manipulability
+
+The Yoshikawa manipulability index measures how far a configuration `q` is from a singularity — a configuration where `J(q)` loses rank and some tip velocity directions become unreachable no matter how fast the joints move:
+
+```
+w(q) = sqrt(det(J(q) * J(q)^T))
+```
+
+`J*J^T` is symmetric positive semi-definite by construction, so its determinant is mathematically never negative — but computed in `float`, right at or past a singularity the determinant can land a hair below zero from rounding alone. `manipulability()` clamps the radicand at 0 before the square root, so the result is always a finite, non-negative `float` (never `NaN`) — `0.0f` at a singularity rather than an ill-defined negative-root result.
+
+`w(q)` is a single scalar summary; the **smallest singular value** of `J(q)` (e.g. via `Eigen::JacobiSVD`) is a related, more granular measure of the same thing — it goes to 0 exactly where `w(q)` does, but also identifies *which* direction in velocity space is becoming unreachable (the corresponding right-singular vector), which `w(q)` alone does not.
+
+Both are **continuous** distance-to-singularity measures: they shrink smoothly to 0 as `q` approaches a singularity, from any direction. This is a different kind of tool than the small `constexpr` epsilons already in `inverseKinematics()`'s `solveTheta6()` (`kZeroSingularityEps`, `kPiSingularityEps` in `src/ur_kinematics.cpp`) — those are **binary** guards that pin a *specific downstream formula* (an `atan2` that divides by `sin(theta5)`) to a fixed fallback value once `theta5` gets numerically close enough to 0 or ±π that the division would blow up. They answer "is this one division about to be unsafe?", not "how manipulable is this configuration overall?" — `jacobian()`/`manipulability()` are a general-purpose tool usable at any `q`, independent of `inverseKinematics()` and its specific solver internals.
+
+## The three UR singularity families
+
+A UR's rank-6 Jacobian drops rank at three configuration families (using this library's joint numbering, 1-indexed, radians):
+
+1. **Wrist singularity** — `theta5 = 0` (or `±π`). Joint 6's axis becomes (anti-)parallel to joint 4's axis, so the wrist loses one rotational degree of freedom (two joints now contribute the same rotation direction). This is the same condition `solveTheta6()`'s `kZeroSingularityEps`/`kPiSingularityEps` guard against on the IK side, from the opposite direction — there, an underdetermined `theta6` at the singularity; here, a rank-deficient `J`.
+2. **Elbow singularity** — `theta3 = 0` or `theta3 = π`. The arm is fully extended or fully folded; the elbow can no longer move the wrist centre perpendicular to the (shoulder → wrist-centre) line, collapsing one linear degree of freedom.
+3. **Shoulder singularity** — the wrist centre lies on the joint-1 (base) rotation axis. Rotating the base contributes no tip velocity component in the direction toward/away from that axis, since the wrist centre is sitting on it.
+
+At each, `rank(J(q)) < 6`, `w(q) -> 0`, and the smallest singular value of `J(q) -> 0` — empirically (see `tests/test_jacobian.cpp`), both measure on the order of `1e-5`-`1e-8` at an exact wrist or elbow singularity, several orders of magnitude below a generic configuration.
+
+## Analytical vs. geometric Jacobian: why geometric
+
+A manipulator Jacobian can be built two ways:
+
+- **Geometric (spatial)** — the one this library implements. Columns are `[z_i x (p_end - p_i); z_i]`, and the angular rows relate joint rates to true angular velocity `omega`. Convention-free: it doesn't depend on any particular choice of orientation representation.
+- **Analytical** — relates joint rates to the *time-derivative of a specific orientation parameterisation* (e.g. Euler angles), `x_dot_analytical = [v; d(euler)/dt]`. This requires an extra transformation (an Euler-rate mapping matrix, itself a function of the current Euler angles and singular at certain orientations of its own — gimbal lock in the representation, on top of any physical singularity) and is tied to *which* Euler convention you pick.
+
+This library picked geometric deliberately because of **Quirk Q5** (see [Kinematics Theory](Kinematics-Theory#euler-convention-asymmetry-quirk-q5)): `forwardKinematics()` *extracts* `pose::m_eulerAngles` as `R = RotY(gamma)*RotZ(beta)*RotX(alpha)`, while `inverseKinematics()` *composes* its target rotation from the same triple as `R = RotX(alpha)*RotY(beta)*RotZ(gamma)` — two different, non-inverse conventions for the same stored triple. An analytical Jacobian would have to commit to *one* of those conventions (or a third), and differentiating either through its convention's singularities would add a second, representation-only singularity family layered on top of the three genuine physical ones above — with no way to pick one that's obviously "correct" given the library's existing FK/IK asymmetry. The geometric Jacobian sidesteps this entirely: `z_i` and `p_i` come directly from the same rotation/translation blocks `forwardKinematics()` already computes, with no Euler angles involved anywhere in the derivation, so it has no relationship to (and is not affected by) Quirk Q5 at all.
+
+This is also why the validation tests (`tests/test_jacobian.cpp`) check the Jacobian's **linear** rows against a finite difference of tip *position* (convention-free), but validate the **angular** rows structurally (each column's angular part is a unit vector, since it's defined to equal a rotation axis) rather than by finite-differencing the stored Euler angles — differentiating through the FK-extract convention would silently test that convention's Euler-rate behavior, not the geometric angular velocity `jacobian()` actually returns.
+
+See the [UR Class API](UR-Class-API) page for the exact `jacobian()`/`manipulability()` signatures.

--- a/docs/wiki/UR-Class-API.md
+++ b/docs/wiki/UR-Class-API.md
@@ -108,7 +108,7 @@ Equivalent to `inverseKinematics(targetPose).anyValid()` — use this when you o
 
 `jacobian(q)` returns the geometric (spatial) Jacobian at joint configuration `q`, expressed in the base frame: rows 0-2 are the tip's linear-velocity contribution per joint, rows 3-5 the angular-velocity contribution, columns are joints 1-6. Relates joint velocities to the tip's spatial twist: `x_dot = J(q) * q_dot`. See [Jacobian Theory](Jacobian-Theory) for the derivation, why this (rather than an Euler-rate/analytical Jacobian) was chosen, and the three UR singularity families.
 
-`manipulability(q)` returns the Yoshikawa manipulability index `w(q) = sqrt(det(J(q) * J(q)^T))`, a scalar distance-to-singularity measure — 0 at a singularity, larger away from one. Returns `0.0f` (never `NaN` or negative) when the radicand goes slightly negative from float rounding at or beyond a singularity.
+`manipulability(q)` returns the Yoshikawa manipulability index `w(q) = sqrt(det(J(q) * J(q)^T))`, a scalar distance-to-singularity measure — 0 at a singularity, larger away from one. For this library's square (non-redundant, 6x6) Jacobian, `sqrt(det(J * J^T)) == abs(det(J))`, so it's computed as `abs(J(q).determinant())` — equivalent, but faster and never at risk of a negative-radicand `NaN` at or beyond a singularity.
 
 Same precondition/side effects as `forwardKinematics()`: `q` must be finite and within `[-2π, 2π]` per joint (both functions call it internally), and both refresh the joint-pose/transform cache used by `operator<<`.
 

--- a/docs/wiki/UR-Class-API.md
+++ b/docs/wiki/UR-Class-API.md
@@ -99,6 +99,19 @@ if (auto idx = universalRobots::nearestSolution(sols, currentJointVector))
 
 Equivalent to `inverseKinematics(targetPose).anyValid()` — use this when you only need a yes/no reachability answer.
 
+## `jacobian` and `manipulability`
+
+```cpp
+[[nodiscard]] Eigen::Matrix<float, 6, 6> jacobian(const JointVector& q) const;
+[[nodiscard]] float manipulability(const JointVector& q) const;
+```
+
+`jacobian(q)` returns the geometric (spatial) Jacobian at joint configuration `q`, expressed in the base frame: rows 0-2 are the tip's linear-velocity contribution per joint, rows 3-5 the angular-velocity contribution, columns are joints 1-6. Relates joint velocities to the tip's spatial twist: `x_dot = J(q) * q_dot`. See [Jacobian Theory](Jacobian-Theory) for the derivation, why this (rather than an Euler-rate/analytical Jacobian) was chosen, and the three UR singularity families.
+
+`manipulability(q)` returns the Yoshikawa manipulability index `w(q) = sqrt(det(J(q) * J(q)^T))`, a scalar distance-to-singularity measure — 0 at a singularity, larger away from one. Returns `0.0f` (never `NaN` or negative) when the radicand goes slightly negative from float rounding at or beyond a singularity.
+
+Same precondition/side effects as `forwardKinematics()`: `q` must be finite and within `[-2π, 2π]` per joint (both functions call it internally), and both refresh the joint-pose/transform cache used by `operator<<`.
+
 ## `generateRandomReachablePose`
 
 ```cpp

--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -191,6 +191,18 @@ namespace universalRobots
 		[[nodiscard]] IkSolutions inverseKinematics(const pose& targetTipPose) const;
 		/// Returns true iff inverseKinematics(targetPose).anyValid().
 		[[nodiscard]] bool isPoseReachable(const pose& targetPose) const;
+		/// Geometric (spatial) Jacobian at joint configuration q, expressed in the base
+		/// frame: maps joint velocities to the tip's spatial twist [linear; angular]
+		/// (rows 0-2 linear, rows 3-5 angular; columns are joints 1-6). See
+		/// docs/wiki/Jacobian-Theory for the derivation and why this convention (rather
+		/// than the analytical/Euler-rate Jacobian) was chosen.
+		/// Precondition/side effects: same as forwardKinematics() (validates q, refreshes
+		/// the joint-pose/transform cache).
+		[[nodiscard]] Eigen::Matrix<float, 6, 6> jacobian(const JointVector& q) const;
+		/// Yoshikawa manipulability index w(q) = sqrt(det(J(q) * J(q)^T)); 0 (not NaN)
+		/// at or beyond a singularity, where float noise can make the radicand
+		/// slightly negative.
+		[[nodiscard]] float manipulability(const JointVector& q) const;
 		pose generateRandomReachablePose() const;
 		/// Deterministic overload: samples with a caller-supplied seed instead of std::random_device.
 		pose generateRandomReachablePose(unsigned int seed) const;

--- a/include/ur_kinematics/ur_kinematics.h
+++ b/include/ur_kinematics/ur_kinematics.h
@@ -199,9 +199,8 @@ namespace universalRobots
 		/// Precondition/side effects: same as forwardKinematics() (validates q, refreshes
 		/// the joint-pose/transform cache).
 		[[nodiscard]] Eigen::Matrix<float, 6, 6> jacobian(const JointVector& q) const;
-		/// Yoshikawa manipulability index w(q) = sqrt(det(J(q) * J(q)^T)); 0 (not NaN)
-		/// at or beyond a singularity, where float noise can make the radicand
-		/// slightly negative.
+		/// Yoshikawa manipulability index w(q) = sqrt(det(J(q) * J(q)^T)), computed as
+		/// abs(det(J(q))) (equal for a square Jacobian, and never negative or NaN).
 		[[nodiscard]] float manipulability(const JointVector& q) const;
 		pose generateRandomReachablePose() const;
 		/// Deterministic overload: samples with a caller-supplied seed instead of std::random_device.

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -500,14 +500,14 @@ namespace universalRobots
 	/// <summary>
 	/// Yoshikawa manipulability index w(q) = sqrt(det(J(q) * J(q)^T)).
 	/// </summary>
-	// Clamped at 0 rather than left to produce NaN: at/beyond a singularity the
-	// radicand can go slightly negative from float noise alone (J*J^T is PSD in
-	// theory, but not bit-exactly so once det() is computed in float).
+	// For a square (non-redundant) Jacobian, det(J * J^T) = det(J)^2, so
+	// sqrt(det(J * J^T)) == abs(det(J)) -- computing it this way avoids the 6x6
+	// J * J^T product and sidesteps the risk of a float-noise-negative radicand
+	// under a sqrt entirely, rather than computing then clamping it.
 	float UR::manipulability(const JointVector& q) const
 	{
 		const Eigen::Matrix<float, 6, 6> J = jacobian(q);
-		const float radicand = (J * J.transpose()).determinant();
-		return std::sqrt(std::max(radicand, 0.0f));
+		return std::abs(J.determinant());
 	}
 
 	/// <summary>

--- a/src/ur_kinematics.cpp
+++ b/src/ur_kinematics.cpp
@@ -467,6 +467,50 @@ namespace universalRobots
 	}
 
 	/// <summary>
+	/// Computes the geometric (spatial) Jacobian at joint configuration q, in the base
+	/// frame. See docs/wiki/Jacobian-Theory.md for the derivation.
+	/// </summary>
+	// All 6 UR joints are revolute, so column i is [z_i x (p_end - p_i); z_i], where
+	// z_i/p_i are the axis/origin of joint i+1 in the base frame. kPoseBearingFrames[i]
+	// (i=0..5) is exactly the frame that carries joint i+1's own rotation (frames
+	// {0,1,2,3,5,7}; see the MDH frame table in docs/wiki/Modified-Denavit-Hartenberg-
+	// Convention.md) -- and since a pure Rot_z(theta_i) rotation changes neither its own
+	// z-axis nor its origin, that frame's z-axis/origin equal the "z_{i-1}/p_{i-1}"
+	// (pre-rotation) quantities the standard formula calls for. Reuses
+	// m_generalTransformationMatrices, already populated by the forwardKinematics(q)
+	// call below -- no transforms are rebuilt.
+	Eigen::Matrix<float, 6, 6> UR::jacobian(const JointVector& q) const
+	{
+		(void)forwardKinematics(q); // refreshes m_generalTransformationMatrices for q
+
+		const Eigen::Vector3f p_end = m_generalTransformationMatrices[8].block<3, 1>(0, 3);
+
+		Eigen::Matrix<float, 6, 6> J;
+		for (unsigned int i = 0; i < m_numDoF; ++i)
+		{
+			const Eigen::Matrix4f& T = m_generalTransformationMatrices[kPoseBearingFrames[i]];
+			const Eigen::Vector3f z_i = T.block<3, 1>(0, 2);
+			const Eigen::Vector3f p_i = T.block<3, 1>(0, 3);
+			J.block<3, 1>(0, i) = z_i.cross(p_end - p_i);
+			J.block<3, 1>(3, i) = z_i;
+		}
+		return J;
+	}
+
+	/// <summary>
+	/// Yoshikawa manipulability index w(q) = sqrt(det(J(q) * J(q)^T)).
+	/// </summary>
+	// Clamped at 0 rather than left to produce NaN: at/beyond a singularity the
+	// radicand can go slightly negative from float noise alone (J*J^T is PSD in
+	// theory, but not bit-exactly so once det() is computed in float).
+	float UR::manipulability(const JointVector& q) const
+	{
+		const Eigen::Matrix<float, 6, 6> J = jacobian(q);
+		const float radicand = (J * J.transpose()).determinant();
+		return std::sqrt(std::max(radicand, 0.0f));
+	}
+
+	/// <summary>
 	/// Generates a valid tip pose by running forward kinematics with random target joint values.
 	/// </summary>
 	/// <returns>randomValidTargetPose</returns>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(ur_kinematics_tests
     test_pose_and_fk_anchors.cpp
     test_properties.cpp
     test_ik_selection.cpp
+    test_jacobian.cpp
 )
 target_include_directories(ur_kinematics_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 # test_math_utils.cpp unit-tests calcTransformationMatrix directly, which is a

--- a/tests/test_jacobian.cpp
+++ b/tests/test_jacobian.cpp
@@ -1,0 +1,217 @@
+// test_jacobian.cpp — task 63: geometric (spatial) Jacobian + manipulability.
+//
+// All tests use a seeded std::mt19937 for determinism.
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+#include <random>
+
+#include <Eigen/Dense>
+#include <ur_kinematics/ur_kinematics.h>
+#include "golden_config.hpp"
+
+namespace
+{
+	constexpr int kSeed = 6300; // distinct from other test files' seeds
+
+	// Finite-difference gate tolerances (task 63 dispatch): eps ~= float eps^(1/3)
+	// (~5e-3 rad) balances truncation error (grows with eps) against float32
+	// cancellation error (grows as eps shrinks) for a single-sided difference
+	// through a float-internal FK chain.
+	constexpr float kFdEps = 5e-3f;
+	constexpr float kFdRelTol = 1e-3f;
+	constexpr float kFdAbsFloor = 1e-5f;
+
+	// Well above the ~1e-5 manipulability / ~1e-8 smallest-singular-value observed
+	// empirically at an exact wrist/elbow singularity, well below a generic
+	// non-singular configuration's values.
+	constexpr float kSingularityEps = 1e-3f;
+} // namespace
+
+// ---- Finite-difference gate: linear rows only (position is convention-free;
+//      orientation is not, see Quirk Q5 -- angular rows are validated structurally
+//      in AngularRowsAreUnitJointAxes below instead). ----
+
+TEST(Jacobian, LinearRowsMatchFiniteDifference)
+{
+	std::mt19937 gen(kSeed);
+	std::uniform_real_distribution<float> dist(-std::numbers::pi_v<float>, std::numbers::pi_v<float>);
+	constexpr int kConfigsPerModel = 20;
+
+	for (const auto& model : goldencfg::models())
+	{
+		universalRobots::UR robot(model.type);
+		for (int iter = 0; iter < kConfigsPerModel; ++iter)
+		{
+			universalRobots::UR::JointVector q{};
+			for (float& j : q)
+				j = dist(gen);
+
+			const Eigen::Matrix<float, 6, 6> J = robot.jacobian(q);
+
+			for (unsigned int i = 0; i < universalRobots::UR::m_numDoF; ++i)
+			{
+				universalRobots::UR::JointVector qPlus = q;
+				qPlus[i] += kFdEps;
+				universalRobots::UR::JointVector qMinus = q;
+				qMinus[i] -= kFdEps;
+				const universalRobots::pose pPlus = robot.forwardKinematics(qPlus);
+				const universalRobots::pose pMinus = robot.forwardKinematics(qMinus);
+
+				for (int row = 0; row < 3; ++row)
+				{
+					// Central difference: O(eps^2) truncation error, vs. O(eps) for a
+					// single-sided difference -- at eps=5e-3 a single-sided difference's
+					// truncation error alone exceeds a 1e-3 relative tolerance for this
+					// chain (verified empirically), while central differences clear it
+					// comfortably (~0.4% worst case observed), making it the right choice
+					// for a tolerance this tight without weakening the gate.
+					const float fd = (pPlus.m_pos[row] - pMinus.m_pos[row]) / (2.0f * kFdEps);
+					const float tol = kFdAbsFloor + kFdRelTol * std::abs(fd);
+					EXPECT_NEAR(J(row, i), fd, tol)
+						<< model.name << " iter " << iter << " col " << i << " row " << row;
+				}
+			}
+		}
+	}
+}
+
+// ---- Angular rows: validated structurally, not via finite-difference (would
+//      require differentiating through the FK-extract Euler convention, which is
+//      asymmetric with IK-compose -- see Quirk Q5, docs/wiki/Kinematics-Theory.md).
+//      Column i's angular part is defined as z_i, the joint-i+1 axis expressed in
+//      the base frame -- check it is a unit vector, as any rotation axis must be. ----
+
+TEST(Jacobian, AngularRowsAreUnitJointAxes)
+{
+	std::mt19937 gen(kSeed + 1);
+	std::uniform_real_distribution<float> dist(-std::numbers::pi_v<float>, std::numbers::pi_v<float>);
+	constexpr int kConfigsPerModel = 20;
+	constexpr float kUnitTol = 1e-4f;
+
+	for (const auto& model : goldencfg::models())
+	{
+		universalRobots::UR robot(model.type);
+		for (int iter = 0; iter < kConfigsPerModel; ++iter)
+		{
+			universalRobots::UR::JointVector q{};
+			for (float& j : q)
+				j = dist(gen);
+
+			const Eigen::Matrix<float, 6, 6> J = robot.jacobian(q);
+			for (unsigned int i = 0; i < universalRobots::UR::m_numDoF; ++i)
+			{
+				const Eigen::Vector3f angular = J.block<3, 1>(3, i);
+				EXPECT_NEAR(angular.norm(), 1.0f, kUnitTol) << model.name << " iter " << iter << " col " << i;
+			}
+		}
+	}
+}
+
+// ---- Determinism / no-throw: jacobian()/manipulability() are pure functions of q,
+//      same argument -> identical result, and never throw for any FK-valid q. ----
+
+TEST(Jacobian, IsDeterministic)
+{
+	universalRobots::UR robot(universalRobots::URtype::UR5);
+	const universalRobots::UR::JointVector q{0.3f, -0.5f, 0.8f, 0.2f, 0.6f, -0.1f};
+
+	const Eigen::Matrix<float, 6, 6> j1 = robot.jacobian(q);
+	const Eigen::Matrix<float, 6, 6> j2 = robot.jacobian(q);
+	EXPECT_TRUE(j1 == j2);
+
+	EXPECT_EQ(robot.manipulability(q), robot.manipulability(q));
+}
+
+TEST(Jacobian, NeverThrowsForFkValidJoints)
+{
+	std::mt19937 gen(kSeed + 2);
+	std::uniform_real_distribution<float> dist(-std::numbers::pi_v<float>, std::numbers::pi_v<float>);
+	constexpr int kDraws = 200;
+
+	for (const auto& model : goldencfg::models())
+	{
+		universalRobots::UR robot(model.type);
+		for (int i = 0; i < kDraws; ++i)
+		{
+			universalRobots::UR::JointVector q{};
+			for (float& j : q)
+				j = dist(gen);
+
+			EXPECT_NO_THROW({ (void)robot.jacobian(q); }) << model.name << " draw " << i;
+			EXPECT_NO_THROW({ (void)robot.manipulability(q); }) << model.name << " draw " << i;
+		}
+	}
+}
+
+// ---- Singular configurations: manipulability -> ~0 and rank(J) < 6. ----
+//
+// Empirically (see PR discussion / task 63): at an exact wrist (theta5=0) or elbow
+// (theta3=0) singularity, manipulability() measures ~1e-5 and the smallest singular
+// value ~1e-8-1e-9 -- both are float-noise-scale artifacts of an analytically-zero
+// quantity, several orders of magnitude below a generic non-singular configuration.
+TEST(Jacobian, WristSingularityDropsRank)
+{
+	for (const auto& model : goldencfg::models())
+	{
+		universalRobots::UR robot(model.type);
+		const universalRobots::UR::JointVector q{0.3f, -0.5f, 0.8f, 0.2f, 0.0f, -0.1f}; // theta5 = 0
+
+		EXPECT_LT(robot.manipulability(q), kSingularityEps) << model.name;
+
+		const Eigen::Matrix<float, 6, 6> J = robot.jacobian(q);
+		const Eigen::JacobiSVD<Eigen::Matrix<float, 6, 6>> svd(J);
+		EXPECT_LT(svd.singularValues()(5), kSingularityEps) << model.name << " smallest singular value";
+		EXPECT_LT(J.fullPivLu().rank(), 6) << model.name;
+	}
+}
+
+TEST(Jacobian, ElbowSingularityDropsRank)
+{
+	for (const auto& model : goldencfg::models())
+	{
+		universalRobots::UR robot(model.type);
+		const universalRobots::UR::JointVector q{0.3f, -0.5f, 0.0f, 0.2f, 0.4f, -0.1f}; // theta3 = 0
+
+		EXPECT_LT(robot.manipulability(q), kSingularityEps) << model.name;
+
+		const Eigen::Matrix<float, 6, 6> J = robot.jacobian(q);
+		const Eigen::JacobiSVD<Eigen::Matrix<float, 6, 6>> svd(J);
+		EXPECT_LT(svd.singularValues()(5), kSingularityEps) << model.name << " smallest singular value";
+		EXPECT_LT(J.fullPivLu().rank(), 6) << model.name;
+	}
+}
+
+// ---- manipulability() never returns NaN/negative, even right at a singularity
+//      where the radicand can go slightly negative from float noise alone. ----
+
+TEST(Jacobian, ManipulabilityNeverNegativeOrNan)
+{
+	std::mt19937 gen(kSeed + 3);
+	std::uniform_real_distribution<float> dist(-std::numbers::pi_v<float>, std::numbers::pi_v<float>);
+	constexpr int kDraws = 200;
+
+	for (const auto& model : goldencfg::models())
+	{
+		universalRobots::UR robot(model.type);
+		for (int i = 0; i < kDraws; ++i)
+		{
+			universalRobots::UR::JointVector q{};
+			for (float& j : q)
+				j = dist(gen);
+
+			const float w = robot.manipulability(q);
+			EXPECT_TRUE(std::isfinite(w)) << model.name << " draw " << i;
+			EXPECT_GE(w, 0.0f) << model.name << " draw " << i;
+		}
+	}
+
+	// Exact wrist singularity: the case most likely to expose float-noise-negative radicand.
+	const universalRobots::UR::JointVector qSingular{0.3f, -0.5f, 0.8f, 0.2f, 0.0f, -0.1f};
+	universalRobots::UR robot(universalRobots::URtype::UR5);
+	const float wSingular = robot.manipulability(qSingular);
+	EXPECT_TRUE(std::isfinite(wSingular));
+	EXPECT_GE(wSingular, 0.0f);
+}

--- a/tests/test_jacobian.cpp
+++ b/tests/test_jacobian.cpp
@@ -183,8 +183,8 @@ TEST(Jacobian, ElbowSingularityDropsRank)
 	}
 }
 
-// ---- manipulability() never returns NaN/negative, even right at a singularity
-//      where the radicand can go slightly negative from float noise alone. ----
+// ---- manipulability() never returns NaN/negative: it is abs(J.determinant()),
+//      which is always finite and non-negative for a finite q. ----
 
 TEST(Jacobian, ManipulabilityNeverNegativeOrNan)
 {
@@ -207,7 +207,7 @@ TEST(Jacobian, ManipulabilityNeverNegativeOrNan)
 		}
 	}
 
-	// Exact wrist singularity: the case most likely to expose float-noise-negative radicand.
+	// Exact wrist singularity: the case most likely to expose an ill-formed result.
 	const universalRobots::UR::JointVector qSingular{0.3f, -0.5f, 0.8f, 0.2f, 0.0f, -0.1f};
 	universalRobots::UR robot(universalRobots::URtype::UR5);
 	const float wSingular = robot.manipulability(qSingular);

--- a/tests/test_jacobian.cpp
+++ b/tests/test_jacobian.cpp
@@ -70,8 +70,7 @@ TEST(Jacobian, LinearRowsMatchFiniteDifference)
 					// for a tolerance this tight without weakening the gate.
 					const float fd = (pPlus.m_pos[row] - pMinus.m_pos[row]) / (2.0f * kFdEps);
 					const float tol = kFdAbsFloor + kFdRelTol * std::abs(fd);
-					EXPECT_NEAR(J(row, i), fd, tol)
-						<< model.name << " iter " << iter << " col " << i << " row " << row;
+					EXPECT_NEAR(J(row, i), fd, tol) << model.name << " iter " << iter << " col " << i << " row " << row;
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Adds `[[nodiscard]] Eigen::Matrix<float,6,6> jacobian(const JointVector& q) const` and `[[nodiscard]] float manipulability(const JointVector& q) const` to `UR` -- additive only, no existing FK/IK signatures or golden values touched.
- **Convention**: geometric (spatial) Jacobian, base frame -- chosen deliberately over the analytical/Euler-rate Jacobian because it needs no orientation representation, sidestepping the FK-extract vs IK-compose Euler asymmetry (Quirk Q5, see `docs/wiki/Kinematics-Theory.md`). Column `i`: linear = `z_i x (p_end - p_i)`, angular = `z_i`, reusing `m_generalTransformationMatrices` already built by `forwardKinematics()` -- no transforms rebuilt.
- `manipulability(q) = sqrt(det(J*J^T))`, radicand clamped at 0 so it never returns `NaN`/negative from float noise at/beyond a singularity.
- New `docs/wiki/Jacobian-Theory.md` (linked from `Home.md`): `x_dot = J(q)*q_dot` definition, the geometric-Jacobian derivation, the column -> MDH-frame mapping, manipulability vs. the existing ad-hoc `kZeroSingularityEps`/`kPiSingularityEps` IK guards, the three UR singularity families (wrist `theta5=0`, elbow `theta3=0/pi`, shoulder), and why geometric was chosen over analytical.
- `docs/wiki/UR-Class-API.md` updated with the new signatures.

## Tests (`tests/test_jacobian.cpp`)
- **Finite-difference gate** on the linear rows: central difference (not the forward difference in the issue's formula -- verified empirically that a forward difference's O(eps) truncation error alone exceeds a 1e-3 relative tolerance at eps=5e-3 for this chain; central differences clear it comfortably at ~0.4% worst case observed, so central was used for a real gate rather than loosening the tolerance).
- **Angular rows** validated structurally (unit joint axes) rather than by finite-differencing Euler angles, since that would test the FK-extract convention's Euler-rate behavior rather than the geometric angular velocity this returns (see Quirk Q5 discussion in the new theory doc).
- **Singular-config tests**: at an exact wrist (`theta5=0`) and elbow (`theta3=0`) singularity, `manipulability() < 1e-3` and `rank(J) < 6` (smallest singular value also checked), for all 3 models.
- Determinism (same `q` -> identical `J`/`w`) and no-throw sweeps (200 draws x 3 models).

## Gates
- Golden diff empty (`git diff --stat -- tests/golden/`): confirmed, no golden file touched.
- 72/72 local tests green (65 pre-existing + 7 new).
- All-float throughout; no existing public signature changed.
- `/W4 /WX` (MSVC) clean build, no warnings.

## Test plan
- [x] CI green cross-platform (8 jobs)
- [x] CodeRabbit review addressed (or genuine rate-limit waited out/documented)

Per dispatch: **not merging this one** -- reporting ready-for-review only, human owns the merge on this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `jacobian()` to compute the robot’s 6×6 geometric/spatial Jacobian.
  * Added `manipulability()` to report Yoshikawa’s index; results are guaranteed non-negative and never NaN, including at singularities.
* **Documentation**
  * Expanded the wiki and UR API docs with Jacobian interpretation and manipulability/singularity guidance, and added “Jacobian Theory” to navigation.
* **Tests**
  * Added Jacobian tests for accuracy (finite differences), angular-axis structure, determinism, valid inputs, and singularity behavior (near-zero manipulability/rank deficiency).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->